### PR TITLE
Feat/3912 coupon management networking

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		03DCB7402624AD7D00C8953D /* CouponListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */; };
 		03DCB7442624AD9B00C8953D /* CouponListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */; };
 		03DCB7522624B3BE00C8953D /* coupons-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 03DCB7512624B3BE00C8953D /* coupons-all.json */; };
+		03DCB76426258CA200C8953D /* coupons-minimal.json in Resources */ = {isa = PBXBuildFile; fileRef = 03DCB76326258CA200C8953D /* coupons-minimal.json */; };
 		21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */; };
 		24F98C522502E79800F49B68 /* FeatureFlagsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */; };
 		24F98C542502E8DD00F49B68 /* Bundle+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */; };
@@ -516,6 +517,7 @@
 		03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListMapper.swift; sourceTree = "<group>"; };
 		03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListMapperTests.swift; sourceTree = "<group>"; };
 		03DCB7512624B3BE00C8953D /* coupons-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupons-all.json"; sourceTree = "<group>"; };
+		03DCB76326258CA200C8953D /* coupons-minimal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "coupons-minimal.json"; sourceTree = "<group>"; };
 		24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsRemote.swift; sourceTree = "<group>"; };
 		24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Woo.swift"; sourceTree = "<group>"; };
 		24F98C552502EA4800F49B68 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
@@ -1335,6 +1337,7 @@
 				B5147875211B9227007562E5 /* broken-orders-mark-2.json */,
 				74A7B4BD217A841400E85A8B /* broken-settings-general.json */,
 				03DCB7512624B3BE00C8953D /* coupons-all.json */,
+				03DCB76326258CA200C8953D /* coupons-minimal.json */,
 				B58D10C72114D21C00107ED4 /* generic_error.json */,
 				B53EF53521813681003E146F /* generic_success.json */,
 				B57B1E6B21C94C9F0046E764 /* timeout_error.json */,
@@ -1845,6 +1848,7 @@
 				D8C11A5C22DFCF8100D4A88D /* order-stats-v4-year-alt.json in Resources */,
 				B56C1EBA20EA7D2C00D749F9 /* sites.json in Resources */,
 				74A1D263211898F000931DFA /* site-visits-day.json in Resources */,
+				03DCB76426258CA200C8953D /* coupons-minimal.json in Resources */,
 				02C54CC624D3E938007D658F /* product-variations-load-all-manage-stock-two-states.json in Resources */,
 				D823D90722376B4800C90817 /* shipment_tracking_new_custom_provider.json in Resources */,
 				268B68FD24C87E37007EBF1D /* leaderboards-year-alt.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		03DCB7822627394500C8953D /* CouponMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB7812627394500C8953D /* CouponMapperTests.swift */; };
 		03DCB786262739D200C8953D /* CouponMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB785262739D200C8953D /* CouponMapper.swift */; };
 		03DCB78A26273A8300C8953D /* coupon-minimal.json in Resources */ = {isa = PBXBuildFile; fileRef = 03DCB78926273A8300C8953D /* coupon-minimal.json */; };
+		03DCB796262741E000C8953D /* Coupon+Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB795262741E000C8953D /* Coupon+Decoder.swift */; };
 		21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */; };
 		24F98C522502E79800F49B68 /* FeatureFlagsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */; };
 		24F98C542502E8DD00F49B68 /* Bundle+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */; };
@@ -530,6 +531,7 @@
 		03DCB7812627394500C8953D /* CouponMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponMapperTests.swift; sourceTree = "<group>"; };
 		03DCB785262739D200C8953D /* CouponMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponMapper.swift; sourceTree = "<group>"; };
 		03DCB78926273A8300C8953D /* coupon-minimal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "coupon-minimal.json"; sourceTree = "<group>"; };
+		03DCB795262741E000C8953D /* Coupon+Decoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Coupon+Decoder.swift"; sourceTree = "<group>"; };
 		24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsRemote.swift; sourceTree = "<group>"; };
 		24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Woo.swift"; sourceTree = "<group>"; };
 		24F98C552502EA4800F49B68 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
@@ -1485,6 +1487,7 @@
 				B505F6CC20BEE37E00BB1B69 /* AccountMapper.swift */,
 				93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */,
 				740211E221939C83002248DA /* CommentResultMapper.swift */,
+				03DCB795262741E000C8953D /* Coupon+Decoder.swift */,
 				03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */,
 				03DCB785262739D200C8953D /* CouponMapper.swift */,
 				B524193E21AC5FE400D6FC0A /* DotcomDeviceMapper.swift */,
@@ -2190,6 +2193,7 @@
 				45E3EEBB237009CF00A826AC /* ShippingLine.swift in Sources */,
 				CE6BFEEA2236E191005C79FB /* ProductType.swift in Sources */,
 				CE6D666C2379E19D007835A1 /* Array+Woo.swift in Sources */,
+				03DCB796262741E000C8953D /* Coupon+Decoder.swift in Sources */,
 				B557DA0B20975D7E005962F4 /* WooAPIVersion.swift in Sources */,
 				CE6BFEE82236D133005C79FB /* ProductDimensions.swift in Sources */,
 				45152811257A81730076B03C /* ProductAttributeMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		02E7FFCB256218F600C53030 /* ShippingLabelRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E7FFCA256218F600C53030 /* ShippingLabelRemoteTests.swift */; };
 		02E7FFCF25621C7900C53030 /* shipping-label-print.json in Resources */ = {isa = PBXBuildFile; fileRef = 02E7FFCE25621C7900C53030 /* shipping-label-print.json */; };
 		02F096C22406691100C0C1D5 /* media-library.json in Resources */ = {isa = PBXBuildFile; fileRef = 02F096C12406691100C0C1D5 /* media-library.json */; };
+		03DCB72626244B9B00C8953D /* Coupon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB72526244B9B00C8953D /* Coupon.swift */; };
 		21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */; };
 		24F98C522502E79800F49B68 /* FeatureFlagsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */; };
 		24F98C542502E8DD00F49B68 /* Bundle+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */; };
@@ -508,6 +509,7 @@
 		02E7FFCA256218F600C53030 /* ShippingLabelRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelRemoteTests.swift; sourceTree = "<group>"; };
 		02E7FFCE25621C7900C53030 /* shipping-label-print.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-print.json"; sourceTree = "<group>"; };
 		02F096C12406691100C0C1D5 /* media-library.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-library.json"; sourceTree = "<group>"; };
+		03DCB72526244B9B00C8953D /* Coupon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coupon.swift; sourceTree = "<group>"; };
 		24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsRemote.swift; sourceTree = "<group>"; };
 		24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Woo.swift"; sourceTree = "<group>"; };
 		24F98C552502EA4800F49B68 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
@@ -1275,6 +1277,7 @@
 				B505F6CE20BEE38B00BB1B69 /* Account.swift */,
 				93D8BBFA226BBC5100AD2EB3 /* AccountSettings.swift */,
 				B5BB1D0F20A237FB00112D92 /* Address.swift */,
+				03DCB72526244B9B00C8953D /* Coupon.swift */,
 				B53EF53721813806003E146F /* DotcomError.swift */,
 				24F98C552502EA4800F49B68 /* FeatureFlag.swift */,
 				B5A2417C217F9ECC00595DEF /* MetaContainer.swift */,
@@ -2066,6 +2069,7 @@
 				021C7BF723863D1800A3BCBD /* Encodable+Serialization.swift in Sources */,
 				0219B03923964BB3007DCD5E /* ProductShippingClassMapper.swift in Sources */,
 				7452387321124B7700A973CD /* AnyCodable.swift in Sources */,
+				03DCB72626244B9B00C8953D /* Coupon.swift in Sources */,
 				026CF61E237D6985009563D4 /* ProductVariationListMapper.swift in Sources */,
 				CE43066E2347CBA70073CBFF /* OrderItemTaxRefund.swift in Sources */,
 				26455E2125F66951008A1D32 /* ProductAttributeTerm.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -75,6 +75,10 @@
 		03DCB76426258CA200C8953D /* coupons-minimal.json in Resources */ = {isa = PBXBuildFile; fileRef = 03DCB76326258CA200C8953D /* coupons-minimal.json */; };
 		03DCB76C262591C400C8953D /* CouponsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB76B262591C400C8953D /* CouponsRemoteTests.swift */; };
 		03DCB772262591D900C8953D /* CouponsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB771262591D900C8953D /* CouponsRemote.swift */; };
+		03DCB77E262738E300C8953D /* coupon.json in Resources */ = {isa = PBXBuildFile; fileRef = 03DCB77D262738E200C8953D /* coupon.json */; };
+		03DCB7822627394500C8953D /* CouponMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB7812627394500C8953D /* CouponMapperTests.swift */; };
+		03DCB786262739D200C8953D /* CouponMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB785262739D200C8953D /* CouponMapper.swift */; };
+		03DCB78A26273A8300C8953D /* coupon-minimal.json in Resources */ = {isa = PBXBuildFile; fileRef = 03DCB78926273A8300C8953D /* coupon-minimal.json */; };
 		21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */; };
 		24F98C522502E79800F49B68 /* FeatureFlagsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */; };
 		24F98C542502E8DD00F49B68 /* Bundle+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */; };
@@ -522,6 +526,10 @@
 		03DCB76326258CA200C8953D /* coupons-minimal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "coupons-minimal.json"; sourceTree = "<group>"; };
 		03DCB76B262591C400C8953D /* CouponsRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponsRemoteTests.swift; sourceTree = "<group>"; };
 		03DCB771262591D900C8953D /* CouponsRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponsRemote.swift; sourceTree = "<group>"; };
+		03DCB77D262738E200C8953D /* coupon.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = coupon.json; sourceTree = "<group>"; };
+		03DCB7812627394500C8953D /* CouponMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponMapperTests.swift; sourceTree = "<group>"; };
+		03DCB785262739D200C8953D /* CouponMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponMapper.swift; sourceTree = "<group>"; };
+		03DCB78926273A8300C8953D /* coupon-minimal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "coupon-minimal.json"; sourceTree = "<group>"; };
 		24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsRemote.swift; sourceTree = "<group>"; };
 		24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Woo.swift"; sourceTree = "<group>"; };
 		24F98C552502EA4800F49B68 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
@@ -1344,6 +1352,8 @@
 				74A7B4BD217A841400E85A8B /* broken-settings-general.json */,
 				03DCB7512624B3BE00C8953D /* coupons-all.json */,
 				03DCB76326258CA200C8953D /* coupons-minimal.json */,
+				03DCB77D262738E200C8953D /* coupon.json */,
+				03DCB78926273A8300C8953D /* coupon-minimal.json */,
 				B58D10C72114D21C00107ED4 /* generic_error.json */,
 				B53EF53521813681003E146F /* generic_success.json */,
 				B57B1E6B21C94C9F0046E764 /* timeout_error.json */,
@@ -1476,6 +1486,7 @@
 				93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */,
 				740211E221939C83002248DA /* CommentResultMapper.swift */,
 				03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */,
+				03DCB785262739D200C8953D /* CouponMapper.swift */,
 				B524193E21AC5FE400D6FC0A /* DotcomDeviceMapper.swift */,
 				24F98C572502EA8800F49B68 /* FeatureFlagMapper.swift */,
 				26B2F74424C5573F0065CCC8 /* LeaderboardListMapper.swift */,
@@ -1592,6 +1603,7 @@
 				9387A6EF226E3F15001B53D7 /* AccountSettingsMapperTests.swift */,
 				74AB0AC921948CE4008220CD /* CommentResultMapperTests.swift */,
 				03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */,
+				03DCB7812627394500C8953D /* CouponMapperTests.swift */,
 				B524194221AC622500D6FC0A /* DotcomDeviceMapperTests.swift */,
 				B554FA922180C17200C54DFF /* NoteHashListMapperTests.swift */,
 				B5C151BF217EE3FB00C7BDC1 /* NoteListMapperTests.swift */,
@@ -1788,6 +1800,7 @@
 				B5A2417B217F98FC00595DEF /* broken-notifications.json in Resources */,
 				D823D91422377EE600C90817 /* shipment_tracking_providers.json in Resources */,
 				4599FC5C24A6276F0056157A /* product-tags-all.json in Resources */,
+				03DCB77E262738E300C8953D /* coupon.json in Resources */,
 				74A7B4BE217A841400E85A8B /* broken-settings-general.json in Resources */,
 				026CF624237D839B009563D4 /* product-variations-load-all.json in Resources */,
 				B5A24179217F98F600595DEF /* notifications-load-all.json in Resources */,
@@ -1830,6 +1843,7 @@
 				74C947862193A6C70024CB60 /* comment-moderate-unapproved.json in Resources */,
 				B559EBAA20A0B5CD00836CD4 /* orders-load-all.json in Resources */,
 				74C8F06620EEB76400B6EDC9 /* order-notes.json in Resources */,
+				03DCB78A26273A8300C8953D /* coupon-minimal.json in Resources */,
 				7426CA1321AF34A3004E9FFC /* site-api.json in Resources */,
 				453305ED2459E1AA00264E50 /* site-post.json in Resources */,
 				74749B99224135C4005C4CF2 /* product.json in Resources */,
@@ -2118,6 +2132,7 @@
 				31D27C8726028CE9002EDB1D /* SitePluginsMapper.swift in Sources */,
 				74D522B62113607F00042831 /* StatGranularity.swift in Sources */,
 				02C2549A25636E1500A04423 /* ShippingLabelAddress.swift in Sources */,
+				03DCB786262739D200C8953D /* CouponMapper.swift in Sources */,
 				B518662220A097C200037A38 /* Network.swift in Sources */,
 				B572F69A21AC475C003EEFF0 /* DevicesRemote.swift in Sources */,
 				B518662420A099BF00037A38 /* AlamofireNetwork.swift in Sources */,
@@ -2271,6 +2286,7 @@
 				B554FA932180C17200C54DFF /* NoteHashListMapperTests.swift in Sources */,
 				74002D6A2118B26100A63C19 /* SiteVisitStatsMapperTests.swift in Sources */,
 				743E84FA221742E300FAC9D7 /* ShipmentsRemoteTests.swift in Sources */,
+				03DCB7822627394500C8953D /* CouponMapperTests.swift in Sources */,
 				03DCB76C262591C400C8953D /* CouponsRemoteTests.swift in Sources */,
 				743E84F822172E1F00FAC9D7 /* ShipmentTrackingListMapperTests.swift in Sources */,
 				45ED4F14239E8F2E004F1BE3 /* TaxClassRemoteTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		03DCB7442624AD9B00C8953D /* CouponListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */; };
 		03DCB7522624B3BE00C8953D /* coupons-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 03DCB7512624B3BE00C8953D /* coupons-all.json */; };
 		03DCB76426258CA200C8953D /* coupons-minimal.json in Resources */ = {isa = PBXBuildFile; fileRef = 03DCB76326258CA200C8953D /* coupons-minimal.json */; };
+		03DCB76C262591C400C8953D /* CouponsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB76B262591C400C8953D /* CouponsRemoteTests.swift */; };
+		03DCB772262591D900C8953D /* CouponsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB771262591D900C8953D /* CouponsRemote.swift */; };
 		21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */; };
 		24F98C522502E79800F49B68 /* FeatureFlagsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */; };
 		24F98C542502E8DD00F49B68 /* Bundle+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */; };
@@ -518,6 +520,8 @@
 		03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListMapperTests.swift; sourceTree = "<group>"; };
 		03DCB7512624B3BE00C8953D /* coupons-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupons-all.json"; sourceTree = "<group>"; };
 		03DCB76326258CA200C8953D /* coupons-minimal.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "coupons-minimal.json"; sourceTree = "<group>"; };
+		03DCB76B262591C400C8953D /* CouponsRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponsRemoteTests.swift; sourceTree = "<group>"; };
+		03DCB771262591D900C8953D /* CouponsRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponsRemote.swift; sourceTree = "<group>"; };
 		24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsRemote.swift; sourceTree = "<group>"; };
 		24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Woo.swift"; sourceTree = "<group>"; };
 		24F98C552502EA4800F49B68 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
@@ -1098,6 +1102,7 @@
 				B505F6D620BEE58800BB1B69 /* AccountRemoteTests.swift */,
 				93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */,
 				740211E021939908002248DA /* CommentRemoteTests.swift */,
+				03DCB76B262591C400C8953D /* CouponsRemoteTests.swift */,
 				B524194821AC659500D6FC0A /* DevicesRemoteTests.swift */,
 				24F98C5F2502EF8200F49B68 /* FeatureFlagRemoteTests.swift */,
 				26B2F74824C55ACE0065CCC8 /* LeaderboardsRemoteTests.swift */,
@@ -1219,6 +1224,7 @@
 				B557DA0020975500005962F4 /* Remote.swift */,
 				B505F6D020BEE39600BB1B69 /* AccountRemote.swift */,
 				740CF89821937A030023ED3A /* CommentRemote.swift */,
+				03DCB771262591D900C8953D /* CouponsRemote.swift */,
 				B572F69921AC475C003EEFF0 /* DevicesRemote.swift */,
 				24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */,
 				26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */,
@@ -2013,6 +2019,7 @@
 				457453E725A72C9700276508 /* CreateProductVariation.swift in Sources */,
 				B505F6EA20BEFC3700BB1B69 /* MockNetwork.swift in Sources */,
 				CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */,
+				03DCB772262591D900C8953D /* CouponsRemote.swift in Sources */,
 				CE6BFEE52236BF05005C79FB /* Product.swift in Sources */,
 				5726F159248E9D88005AE9B4 /* Models+Copiable.generated.swift in Sources */,
 				7452387221124B7700A973CD /* AnyEncodable.swift in Sources */,
@@ -2264,6 +2271,7 @@
 				B554FA932180C17200C54DFF /* NoteHashListMapperTests.swift in Sources */,
 				74002D6A2118B26100A63C19 /* SiteVisitStatsMapperTests.swift in Sources */,
 				743E84FA221742E300FAC9D7 /* ShipmentsRemoteTests.swift in Sources */,
+				03DCB76C262591C400C8953D /* CouponsRemoteTests.swift in Sources */,
 				743E84F822172E1F00FAC9D7 /* ShipmentTrackingListMapperTests.swift in Sources */,
 				45ED4F14239E8F2E004F1BE3 /* TaxClassRemoteTests.swift in Sources */,
 				D88D5A4D230BD010007B6E01 /* ProductReviewsRemoteTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -69,6 +69,9 @@
 		02E7FFCF25621C7900C53030 /* shipping-label-print.json in Resources */ = {isa = PBXBuildFile; fileRef = 02E7FFCE25621C7900C53030 /* shipping-label-print.json */; };
 		02F096C22406691100C0C1D5 /* media-library.json in Resources */ = {isa = PBXBuildFile; fileRef = 02F096C12406691100C0C1D5 /* media-library.json */; };
 		03DCB72626244B9B00C8953D /* Coupon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB72526244B9B00C8953D /* Coupon.swift */; };
+		03DCB7402624AD7D00C8953D /* CouponListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */; };
+		03DCB7442624AD9B00C8953D /* CouponListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */; };
+		03DCB7522624B3BE00C8953D /* coupons-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 03DCB7512624B3BE00C8953D /* coupons-all.json */; };
 		21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */; };
 		24F98C522502E79800F49B68 /* FeatureFlagsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */; };
 		24F98C542502E8DD00F49B68 /* Bundle+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */; };
@@ -510,6 +513,9 @@
 		02E7FFCE25621C7900C53030 /* shipping-label-print.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-print.json"; sourceTree = "<group>"; };
 		02F096C12406691100C0C1D5 /* media-library.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-library.json"; sourceTree = "<group>"; };
 		03DCB72526244B9B00C8953D /* Coupon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coupon.swift; sourceTree = "<group>"; };
+		03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListMapper.swift; sourceTree = "<group>"; };
+		03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListMapperTests.swift; sourceTree = "<group>"; };
+		03DCB7512624B3BE00C8953D /* coupons-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupons-all.json"; sourceTree = "<group>"; };
 		24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsRemote.swift; sourceTree = "<group>"; };
 		24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Woo.swift"; sourceTree = "<group>"; };
 		24F98C552502EA4800F49B68 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
@@ -1328,6 +1334,7 @@
 				CE20179220E3EFA7005B4C18 /* broken-orders.json */,
 				B5147875211B9227007562E5 /* broken-orders-mark-2.json */,
 				74A7B4BD217A841400E85A8B /* broken-settings-general.json */,
+				03DCB7512624B3BE00C8953D /* coupons-all.json */,
 				B58D10C72114D21C00107ED4 /* generic_error.json */,
 				B53EF53521813681003E146F /* generic_success.json */,
 				B57B1E6B21C94C9F0046E764 /* timeout_error.json */,
@@ -1459,6 +1466,7 @@
 				B505F6CC20BEE37E00BB1B69 /* AccountMapper.swift */,
 				93D8BBFC226BBEE800AD2EB3 /* AccountSettingsMapper.swift */,
 				740211E221939C83002248DA /* CommentResultMapper.swift */,
+				03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */,
 				B524193E21AC5FE400D6FC0A /* DotcomDeviceMapper.swift */,
 				24F98C572502EA8800F49B68 /* FeatureFlagMapper.swift */,
 				26B2F74424C5573F0065CCC8 /* LeaderboardListMapper.swift */,
@@ -1499,8 +1507,8 @@
 				453305E82459DF2100264E50 /* PostMapper.swift */,
 				31D27C8626028CE9002EDB1D /* SitePluginsMapper.swift */,
 				74046E1E217A6B70007DD7BF /* SiteSettingsMapper.swift */,
-				74A1D26C21189DFE00931DFA /* SiteVisitStatsMapper.swift */,
 				B53EF53B21814900003E146F /* SuccessResultMapper.swift */,
+				74A1D26C21189DFE00931DFA /* SiteVisitStatsMapper.swift */,
 				450106902399B2C800E24722 /* TaxClassListMapper.swift */,
 				74ABA1D2213F25AE00FFAD30 /* TopEarnerStatsMapper.swift */,
 				026CF61D237D6985009563D4 /* ProductVariationListMapper.swift */,
@@ -1574,6 +1582,7 @@
 				B505F6D220BEE3A500BB1B69 /* AccountMapperTests.swift */,
 				9387A6EF226E3F15001B53D7 /* AccountSettingsMapperTests.swift */,
 				74AB0AC921948CE4008220CD /* CommentResultMapperTests.swift */,
+				03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */,
 				B524194221AC622500D6FC0A /* DotcomDeviceMapperTests.swift */,
 				B554FA922180C17200C54DFF /* NoteHashListMapperTests.swift */,
 				B5C151BF217EE3FB00C7BDC1 /* NoteListMapperTests.swift */,
@@ -1780,6 +1789,7 @@
 				D8FBFF2722D529F2006E3336 /* order-stats-v4-month.json in Resources */,
 				D88D5A43230BC668007B6E01 /* reviews-single.json in Resources */,
 				02DD6492248A3EC00082523E /* product-external.json in Resources */,
+				03DCB7522624B3BE00C8953D /* coupons-all.json in Resources */,
 				45A4B85C25D2FAB500776FB4 /* shipping-label-address-validation-error.json in Resources */,
 				740211DF2193985A002248DA /* comment-moderate-spam.json in Resources */,
 				B5147876211B9227007562E5 /* broken-orders-mark-2.json in Resources */,
@@ -2081,6 +2091,7 @@
 				261CF1B8255AE62D0090D8D3 /* PaymentGatewayRemote.swift in Sources */,
 				CE0A0F1522396BF00075ED8D /* ProductAttribute.swift in Sources */,
 				026CF620237D69D6009563D4 /* ProductVariationsRemote.swift in Sources */,
+				03DCB7402624AD7D00C8953D /* CouponListMapper.swift in Sources */,
 				4599FC5E24A62AA70056157A /* ProductTagsRemote.swift in Sources */,
 				7426CA0F21AF2C90004E9FFC /* SiteAPI.swift in Sources */,
 				D87F6151226591E10031A13B /* NullNetwork.swift in Sources */,
@@ -2209,6 +2220,7 @@
 				74AB5B4D21AF354E00859C12 /* SiteAPIMapperTests.swift in Sources */,
 				93D8BC01226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift in Sources */,
 				262E5AD5255ACD6F000B2416 /* PaymentGatewayListMapperTests.swift in Sources */,
+				03DCB7442624AD9B00C8953D /* CouponListMapperTests.swift in Sources */,
 				B5C151C0217EE3FB00C7BDC1 /* NoteListMapperTests.swift in Sources */,
 				026CF622237D7E61009563D4 /* ProductVariationsRemoteTests.swift in Sources */,
 				020D07C023D8587700FD9580 /* MediaRemoteTests.swift in Sources */,

--- a/Networking/Networking/Mapper/Coupon+Decoder.swift
+++ b/Networking/Networking/Mapper/Coupon+Decoder.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension Coupon {
+    /// JSON decoder appropriate for `Coupon` responses.
+    ///
+    static let decoder: JSONDecoder = {
+        let couponDecoder = JSONDecoder()
+        couponDecoder.keyDecodingStrategy = .convertFromSnakeCase
+        couponDecoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
+        return couponDecoder
+    }()
+}

--- a/Networking/Networking/Mapper/CouponListMapper.swift
+++ b/Networking/Networking/Mapper/CouponListMapper.swift
@@ -7,20 +7,11 @@ struct CouponListMapper: Mapper {
     /// We're injecting this field by copying it in after parsing responses, because `siteID` is not returned in any of the Coupon endpoints.
     ///
     let siteID: Int64
-    
-    /// JSON decoder appropriate for `Coupon` responses.
-    ///
-    private static let decoder: JSONDecoder = {
-        let couponDecoder = JSONDecoder()
-        couponDecoder.keyDecodingStrategy = .convertFromSnakeCase
-        couponDecoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
-        return couponDecoder
-    }()
 
     /// (Attempts) to convert a dictionary into `[Coupon]`.
     ///
     func map(response: Data) throws -> [Coupon] {
-        let coupons = try Self.decoder.decode(CouponListEnvelope.self, from: response).coupons
+        let coupons = try Coupon.decoder.decode(CouponListEnvelope.self, from: response).coupons
         return coupons.map { $0.copy(siteId: siteID) }
     }
 }

--- a/Networking/Networking/Mapper/CouponListMapper.swift
+++ b/Networking/Networking/Mapper/CouponListMapper.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Mapper: `Coupon` List
+///
+struct CouponListMapper: Mapper {
+    /// Site we're parsing `Coupon`s for
+    /// We're injecting this field by copying it in after parsing responses, because `siteID` is not returned in any of the Coupon endpoints.
+    ///
+    let siteID: Int64
+    
+    /// JSON decoder appropriate for `Coupon` responses.
+    ///
+    private static let decoder: JSONDecoder = {
+        let couponDecoder = JSONDecoder()
+        couponDecoder.keyDecodingStrategy = .convertFromSnakeCase
+        couponDecoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
+        return couponDecoder
+    }()
+
+    /// (Attempts) to convert a dictionary into `[Coupon]`.
+    ///
+    func map(response: Data) throws -> [Coupon] {
+        let coupons = try Self.decoder.decode(CouponListEnvelope.self, from: response).coupons
+        return coupons.map { $0.copy(siteId: siteID) }
+    }
+}
+
+
+/// CouponListEnvelope Disposable Entity:
+/// Load All Coupons endpoint returns the coupons in the `data` key.
+/// This entity allows us to parse all the things with JSONDecoder.
+///
+private struct CouponListEnvelope: Decodable {
+    let coupons: [Coupon]
+
+    private enum CodingKeys: String, CodingKey {
+        case coupons = "data"
+    }
+}

--- a/Networking/Networking/Mapper/CouponMapper.swift
+++ b/Networking/Networking/Mapper/CouponMapper.swift
@@ -8,19 +8,10 @@ struct CouponMapper: Mapper {
     ///
     let siteID: Int64
 
-    /// JSON decoder appropriate for `Coupon` responses.
-    ///
-    private static let decoder: JSONDecoder = {
-        let couponDecoder = JSONDecoder()
-        couponDecoder.keyDecodingStrategy = .convertFromSnakeCase
-        couponDecoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
-        return couponDecoder
-    }()
-
     /// (Attempts) to convert a dictionary into `Coupon`.
     ///
     func map(response: Data) throws -> Coupon {
-        let coupon = try Self.decoder.decode(CouponEnvelope.self, from: response).coupon
+        let coupon = try Coupon.decoder.decode(CouponEnvelope.self, from: response).coupon
         return coupon.copy(siteId: siteID)
     }
 }

--- a/Networking/Networking/Mapper/CouponMapper.swift
+++ b/Networking/Networking/Mapper/CouponMapper.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Mapper: `Coupon`
+///
+struct CouponMapper: Mapper {
+    /// Site we're parsing `Coupon` for
+    /// We're injecting this field by copying it in after parsing responses, because `siteID` is not returned in any of the Coupon endpoints.
+    ///
+    let siteID: Int64
+
+    /// JSON decoder appropriate for `Coupon` responses.
+    ///
+    private static let decoder: JSONDecoder = {
+        let couponDecoder = JSONDecoder()
+        couponDecoder.keyDecodingStrategy = .convertFromSnakeCase
+        couponDecoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
+        return couponDecoder
+    }()
+
+    /// (Attempts) to convert a dictionary into `Coupon`.
+    ///
+    func map(response: Data) throws -> Coupon {
+        let coupon = try Self.decoder.decode(CouponEnvelope.self, from: response).coupon
+        return coupon.copy(siteId: siteID)
+    }
+}
+
+
+/// CouponEnvelope Disposable Entity:
+/// Load Coupon endpoint returns the coupon in the `data` key.
+/// This entity allows us to parse all the things with JSONDecoder.
+///
+private struct CouponEnvelope: Decodable {
+    let coupon: Coupon
+
+    private enum CodingKeys: String, CodingKey {
+        case coupon = "data"
+    }
+}

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -2,6 +2,87 @@
 // DO NOT EDIT
 
 
+extension Coupon {
+    func copy(
+        siteId: CopiableProp<Int64> = .copy,
+        couponId: CopiableProp<Int64> = .copy,
+        code: CopiableProp<String> = .copy,
+        amount: CopiableProp<String> = .copy,
+        dateCreated: CopiableProp<Date> = .copy,
+        dateModified: CopiableProp<Date> = .copy,
+        discountType: CopiableProp<Coupon.DiscountType> = .copy,
+        description: CopiableProp<String> = .copy,
+        dateExpires: NullableCopiableProp<Date> = .copy,
+        usageCount: CopiableProp<Int64> = .copy,
+        individualUse: CopiableProp<Bool> = .copy,
+        productIds: CopiableProp<[Int64]> = .copy,
+        excludedProductIds: CopiableProp<[Int64]> = .copy,
+        usageLimit: NullableCopiableProp<Int64> = .copy,
+        usageLimitPerUser: NullableCopiableProp<Int64> = .copy,
+        limitUsageToXItems: NullableCopiableProp<Int64> = .copy,
+        freeShipping: CopiableProp<Bool> = .copy,
+        productCategories: CopiableProp<[Int64]> = .copy,
+        excludedProductCategories: CopiableProp<[Int64]> = .copy,
+        excludeSaleItems: CopiableProp<Bool> = .copy,
+        minimumAmount: CopiableProp<String> = .copy,
+        maximumAmount: CopiableProp<String> = .copy,
+        emailRestrictions: CopiableProp<[String]> = .copy,
+        usedBy: CopiableProp<[String]> = .copy
+    ) -> Coupon {
+        let siteId = siteId ?? self.siteId
+        let couponId = couponId ?? self.couponId
+        let code = code ?? self.code
+        let amount = amount ?? self.amount
+        let dateCreated = dateCreated ?? self.dateCreated
+        let dateModified = dateModified ?? self.dateModified
+        let discountType = discountType ?? self.discountType
+        let description = description ?? self.description
+        let dateExpires = dateExpires ?? self.dateExpires
+        let usageCount = usageCount ?? self.usageCount
+        let individualUse = individualUse ?? self.individualUse
+        let productIds = productIds ?? self.productIds
+        let excludedProductIds = excludedProductIds ?? self.excludedProductIds
+        let usageLimit = usageLimit ?? self.usageLimit
+        let usageLimitPerUser = usageLimitPerUser ?? self.usageLimitPerUser
+        let limitUsageToXItems = limitUsageToXItems ?? self.limitUsageToXItems
+        let freeShipping = freeShipping ?? self.freeShipping
+        let productCategories = productCategories ?? self.productCategories
+        let excludedProductCategories = excludedProductCategories ?? self.excludedProductCategories
+        let excludeSaleItems = excludeSaleItems ?? self.excludeSaleItems
+        let minimumAmount = minimumAmount ?? self.minimumAmount
+        let maximumAmount = maximumAmount ?? self.maximumAmount
+        let emailRestrictions = emailRestrictions ?? self.emailRestrictions
+        let usedBy = usedBy ?? self.usedBy
+
+        return Coupon(
+            siteId: siteId,
+            couponId: couponId,
+            code: code,
+            amount: amount,
+            dateCreated: dateCreated,
+            dateModified: dateModified,
+            discountType: discountType,
+            description: description,
+            dateExpires: dateExpires,
+            usageCount: usageCount,
+            individualUse: individualUse,
+            productIds: productIds,
+            excludedProductIds: excludedProductIds,
+            usageLimit: usageLimit,
+            usageLimitPerUser: usageLimitPerUser,
+            limitUsageToXItems: limitUsageToXItems,
+            freeShipping: freeShipping,
+            productCategories: productCategories,
+            excludedProductCategories: excludedProductCategories,
+            excludeSaleItems: excludeSaleItems,
+            minimumAmount: minimumAmount,
+            maximumAmount: maximumAmount,
+            emailRestrictions: emailRestrictions,
+            usedBy: usedBy
+        )
+    }
+}
+
 extension Order {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/Coupon.swift
+++ b/Networking/Networking/Model/Coupon.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+
+// MARK: - Coupon
+
+/// Represents a Coupon entity: https://woocommerce.github.io/woocommerce-rest-api-docs/?shell#coupons
+///
+public struct Coupon {
+    /// `siteId` should be set on a copy in the Mapper as it's not returned by the API.
+    /// Using a default here gives us the benefit of synthesised codable conformance.
+    /// `private(set) var` is required so that `siteId` will still be on the synthesised`init` which `copy()` uses
+    private(set) var siteId: Int64 = 0
+    let couponId: Int64
+    /// The coupon code for use at checkout
+    let code: String
+    /// Discount provided by the coupon, used whether the `discountType` is a percentage or fixed amount type.
+    let amount: String
+    /// Date the coupon was created, in GMT (UTC)
+    let dateCreated: Date
+    /// Date the coupon was modified (or created), in GMT (UTC)
+    let dateModified: Date
+    /// Determines the type of discount that will be applied. Options: `.percent` `.fixedCart` and `.fixedProduct`
+    let discountType: DiscountType
+    let description: String
+    /// Date the coupon will expire, in GMT (UTC)
+    let dateExpires: Date?
+    /// Total number of times this coupon has been used, by all customers
+    let usageCount: Int64
+    /// Whether the coupon can only be used alone (`true`) or in conjunction with other coupons (`false`)
+    let individualUse: Bool
+    /// Product IDs of products this coupon can be used against
+    let productIds: [Int64]
+    /// Product IDs of products this coupon cannot be used against
+    let excludedProductIds: [Int64]
+    /// Total number of times this coupon can be used
+    let usageLimit: Int64?
+    /// Number of times this coupon be used per customer
+    let usageLimitPerUser: Int64?
+    /// Maximum number of items which the coupon can be applied to in the cart
+    let limitUsageToXItems: Int64?
+    /// Whether the coupon should provide free shipping
+    let freeShipping: Bool
+    /// Categories which this coupon applies to
+    let productCategories: [Int64]
+    /// Categories which this coupon cannot be used on
+    let excludedProductCategories: [Int64]
+    /// If `true`, this coupon will not be applied to items that have sale prices
+    let excludeSaleItems: Bool
+    /// Minimum order amount that needs to be in the cart before coupon applies
+    let minimumAmount: String
+    /// Maximum order amount allowed when using the coupon
+    let maximumAmount: String
+    /// Email addresses of customers who are allowed to use this coupon, which may include * as wildcard
+    let emailRestrictions: [String]
+    /// Email addresses of customers who have used this coupon
+    let usedBy: [String]
+
+    public enum DiscountType: String {
+        case percent = "percent"
+        case fixedCart = "fixed_cart"
+        case fixedProduct = "fixed_product"
+    }
+}
+
+
+// MARK: - Codable Conformance
+
+/// Defines all of the Coupon CodingKeys
+/// The model is intended to be decoded with`JSONDecoder.KeyDecodingStrategy.convertFromSnakeCase`
+/// so any specific `CodingKeys` provided here should be in camel case.
+extension Coupon: Codable {
+    enum CodingKeys: String, CodingKey {
+        case couponId = "id"
+        case code
+        case amount
+        case dateCreated = "dateCreatedGmt"
+        case dateModified = "dateModifiedGmt"
+        case discountType
+        case description
+        case dateExpires = "dateExpiresGmt"
+        case usageCount
+        case individualUse
+        case productIds
+        case excludedProductIds
+        case usageLimit
+        case usageLimitPerUser
+        case limitUsageToXItems
+        case freeShipping
+        case productCategories
+        case excludedProductCategories
+        case excludeSaleItems
+        case minimumAmount
+        case maximumAmount
+        case emailRestrictions
+        case usedBy
+    }
+}
+
+extension Coupon.DiscountType: Codable {}
+
+
+// MARK: - Other Conformances
+
+extension Coupon: GeneratedCopiable, GeneratedFakeable, Equatable {}
+
+extension Coupon.DiscountType: GeneratedCopiable, GeneratedFakeable, Equatable {}

--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Coupons: Remote endpoints
+///
+public final class CouponsRemote: Remote {
+    // MARK: - Coupons
+
+    /// Retrieves all of the `Coupon`s from the API.
+    ///
+    /// - Parameters:
+    ///     - siteID
+    ///     - pageNumber:
+    ///     - pageSize:
+    ///     - completion:
+    ///
+    public func loadAllCoupons(for siteID: Int64,
+                               pageNumber: Int = Default.pageNumber,
+                               pageSize: Int = Default.pageSize,
+                               completion: @escaping ([Coupon]?, Error?) -> ()) {
+        let parameters = [
+            ParameterKey.page: String(pageNumber),
+            ParameterKey.perPage: String(pageSize)
+        ]
+
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: Path.coupons,
+                                     parameters: parameters)
+
+        let mapper = CouponListMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+}
+
+// MARK: - Constants
+//
+public extension CouponsRemote {
+    enum Default {
+        public static let pageSize: Int = 25
+        public static let pageNumber: Int = 1
+    }
+
+    private enum Path {
+        static let coupons = "coupons"
+    }
+
+    private enum ParameterKey {
+        static let page: String = "page"
+        static let perPage: String = "per_page"
+    }
+}

--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Coupons: Remote endpoints
 ///
 public final class CouponsRemote: Remote {
-    // MARK: - Coupons
+    // MARK: - Get Coupons
 
     /// Retrieves all of the `Coupon`s from the API.
     ///
@@ -16,7 +16,7 @@ public final class CouponsRemote: Remote {
     public func loadAllCoupons(for siteID: Int64,
                                pageNumber: Int = Default.pageNumber,
                                pageSize: Int = Default.pageSize,
-                               completion: @escaping ([Coupon]?, Error?) -> ()) {
+                               completion: @escaping (Result<[Coupon], Error>) -> ()) {
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize)
@@ -38,8 +38,8 @@ public final class CouponsRemote: Remote {
 //
 public extension CouponsRemote {
     enum Default {
-        public static let pageSize: Int = 25
-        public static let pageNumber: Int = 1
+        public static let pageSize = 25
+        public static let pageNumber = 1
     }
 
     private enum Path {
@@ -47,7 +47,7 @@ public extension CouponsRemote {
     }
 
     private enum ParameterKey {
-        static let page: String = "page"
-        static let perPage: String = "per_page"
+        static let page = "page"
+        static let perPage = "per_page"
     }
 }

--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -32,6 +32,29 @@ public final class CouponsRemote: Remote {
 
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    // MARK: - Delete Coupon
+
+    /// Delete a `Coupon`.
+    ///
+    /// - Parameters:
+    ///     - siteID: Site for which we'll delete the product attribute.
+    ///     - couponID: ID of the Coupon that will be deleted.
+    ///     - completion: Closure to be executed upon completion.
+    ///
+    public func deleteCoupon(for siteID: Int64,
+                             couponID: Int64,
+                             completion: @escaping (Result<Coupon, Error>) -> Void) {
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .delete,
+                                     siteID: siteID,
+                                     path: Path.coupons + "/\(couponID)",
+                                     parameters: [ParameterKey.force: true])
+
+        let mapper = CouponMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
 }
 
 // MARK: - Constants
@@ -49,5 +72,6 @@ public extension CouponsRemote {
     private enum ParameterKey {
         static let page = "page"
         static let perPage = "per_page"
+        static let force = "force"
     }
 }

--- a/Networking/NetworkingTests/Mapper/CouponListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CouponListMapperTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import Networking
+
+class CouponListMapperTests: XCTestCase {
+
+    /// Dummy Site ID.
+    ///
+    private let dummySiteID: Int64 = 12983476
+
+    /// Verifies that the whole list is parsed.
+    ///
+    func test_CouponsList_map_parses_all_coupons_in_response() throws {
+        let coupons = try mapLoadAllCouponsResponse()
+        XCTAssertEqual(coupons.count, 2)
+    }
+
+    /// Verifies that the `siteID` is added in the mapper, to all results, because it's not provided by the API endpoint
+    ///
+    func test_CouponsList_map_includes_siteID_in_parsed_results() throws {
+        let coupons = try mapLoadAllCouponsResponse()
+        guard coupons.count > 0 else {
+            XCTFail("No coupons parsed")
+            return
+        }
+
+        for coupon in coupons {
+            XCTAssertEqual(coupon.siteId, dummySiteID)
+        }
+    }
+
+    /// Verifies that the fields are all parsed correctly
+    ///
+    func test_CouponsList_map_parses_all_fields_in_result() throws {
+        let coupons = try mapLoadAllCouponsResponse()
+        let coupon = coupons[0]
+
+        let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
+
+        XCTAssertEqual(coupon.couponId, 720)
+        XCTAssertEqual(coupon.code, "free shipping")
+        XCTAssertEqual(coupon.amount, "10.00")
+        XCTAssertEqual(coupon.dateCreated, dateFormatter.date(from: "2017-03-21T18:25:02"))
+        XCTAssertEqual(coupon.dateModified, dateFormatter.date(from: "2017-03-21T18:25:02"))
+        XCTAssertEqual(coupon.discountType, .fixedCart)
+        XCTAssertEqual(coupon.description, "Coupon description")
+        XCTAssertEqual(coupon.dateExpires, dateFormatter.date(from: "2017-03-31T18:25:02"))
+        XCTAssertEqual(coupon.usageCount, 10)
+        XCTAssertEqual(coupon.individualUse, true)
+        XCTAssertEqual(coupon.productIds, [12893712, 12389])
+        XCTAssertEqual(coupon.excludedProductIds, [12213])
+        XCTAssertEqual(coupon.usageLimit, 1200)
+        XCTAssertEqual(coupon.usageLimitPerUser, 3)
+        XCTAssertEqual(coupon.limitUsageToXItems, 10)
+        XCTAssertEqual(coupon.freeShipping, true)
+        XCTAssertEqual(coupon.productCategories, [123, 435, 232])
+        XCTAssertEqual(coupon.excludedProductCategories, [908])
+        XCTAssertEqual(coupon.excludeSaleItems, false)
+        XCTAssertEqual(coupon.minimumAmount, "5.00")
+        XCTAssertEqual(coupon.maximumAmount, "500.00")
+        XCTAssertEqual(coupon.emailRestrictions, ["*@a8c.com", "someone.else@example.com"])
+        XCTAssertEqual(coupon.usedBy, ["someone.else@example.com", "person@a8c.com"])
+    }
+
+}
+
+
+// MARK: - Test Helpers
+///
+private extension CouponListMapperTests {
+
+    /// Returns the CouponListMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapCoupons(from filename: String) throws -> [Coupon] {
+        guard let response = Loader.contentsOf(filename) else {
+            return []
+        }
+
+        return try CouponListMapper(siteID: dummySiteID).map(response: response)
+    }
+
+    /// Returns the CouponsMapper output from `coupons-all.json`
+    ///
+    func mapLoadAllCouponsResponse() throws -> [Coupon] {
+        return try mapCoupons(from: "coupons-all")
+    }
+}

--- a/Networking/NetworkingTests/Mapper/CouponListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CouponListMapperTests.swift
@@ -113,7 +113,7 @@ private extension CouponListMapperTests {
     func mapLoadAllCouponsResponse() throws -> [Coupon] {
         return try mapCoupons(from: "coupons-all")
     }
-    
+
     /// Returns the CouponsMapper output from `coupons-minimal.json`
     ///
     func mapLoadMinimalCouponsResponse() throws -> [Coupon] {

--- a/Networking/NetworkingTests/Mapper/CouponListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CouponListMapperTests.swift
@@ -61,6 +61,36 @@ class CouponListMapperTests: XCTestCase {
         XCTAssertEqual(coupon.usedBy, ["someone.else@example.com", "person@a8c.com"])
     }
 
+    func test_CouponsList_map_accepts_nulls_in_expected_optional_fields() throws {
+        let coupons = try mapLoadMinimalCouponsResponse()
+        let coupon = coupons[0]
+
+        let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
+
+        XCTAssertEqual(coupon.couponId, 10714)
+        XCTAssertEqual(coupon.code, "test")
+        XCTAssertEqual(coupon.amount, "0.00")
+        XCTAssertEqual(coupon.dateCreated, dateFormatter.date(from: "2021-04-13T08:26:25"))
+        XCTAssertEqual(coupon.dateModified, dateFormatter.date(from: "2021-04-13T08:26:25"))
+        XCTAssertEqual(coupon.discountType, .fixedCart)
+        XCTAssertEqual(coupon.description, "")
+        XCTAssertEqual(coupon.dateExpires, nil)
+        XCTAssertEqual(coupon.usageCount, 0)
+        XCTAssertEqual(coupon.individualUse, false)
+        XCTAssertEqual(coupon.productIds, [])
+        XCTAssertEqual(coupon.excludedProductIds, [])
+        XCTAssertEqual(coupon.usageLimit, nil)
+        XCTAssertEqual(coupon.usageLimitPerUser, nil)
+        XCTAssertEqual(coupon.limitUsageToXItems, nil)
+        XCTAssertEqual(coupon.freeShipping, false)
+        XCTAssertEqual(coupon.productCategories, [])
+        XCTAssertEqual(coupon.excludedProductCategories, [])
+        XCTAssertEqual(coupon.excludeSaleItems, false)
+        XCTAssertEqual(coupon.minimumAmount, "0.00")
+        XCTAssertEqual(coupon.maximumAmount, "0.00")
+        XCTAssertEqual(coupon.emailRestrictions, [])
+        XCTAssertEqual(coupon.usedBy, [])
+    }
 }
 
 
@@ -82,5 +112,11 @@ private extension CouponListMapperTests {
     ///
     func mapLoadAllCouponsResponse() throws -> [Coupon] {
         return try mapCoupons(from: "coupons-all")
+    }
+    
+    /// Returns the CouponsMapper output from `coupons-minimal.json`
+    ///
+    func mapLoadMinimalCouponsResponse() throws -> [Coupon] {
+        return try mapCoupons(from: "coupons-minimal")
     }
 }

--- a/Networking/NetworkingTests/Mapper/CouponMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CouponMapperTests.swift
@@ -1,38 +1,31 @@
 import XCTest
 @testable import Networking
 
-class CouponListMapperTests: XCTestCase {
+class CouponMapperTests: XCTestCase {
 
     /// Dummy Site ID.
     ///
-    private let dummySiteID: Int64 = 12983476
+    fileprivate let dummySiteID: Int64 = 12983476
 
-    /// Verifies that the whole list is parsed.
+    /// Verifies that the coupon is parsed.
     ///
-    func test_CouponsList_map_parses_all_coupons_in_response() throws {
-        let coupons = try mapLoadAllCouponsResponse()
-        XCTAssertEqual(coupons.count, 2)
+    func test_Coupon_map_parses_all_coupons_in_response() throws {
+        let coupon = try mapRetrieveCouponResponse()
+        XCTAssertNotNil(coupon)
     }
 
-    /// Verifies that the `siteID` is added in the mapper, to all results, because it's not provided by the API endpoint
+    /// Verifies that the `siteID` is added in the mapper, because it's not provided by the API endpoint
     ///
     func test_CouponsList_map_includes_siteID_in_parsed_results() throws {
-        let coupons = try mapLoadAllCouponsResponse()
-        guard coupons.count > 0 else {
-            XCTFail("No coupons parsed")
-            return
-        }
+        let coupon = try mapRetrieveCouponResponse()
 
-        for coupon in coupons {
-            XCTAssertEqual(coupon.siteId, dummySiteID)
-        }
+        XCTAssertEqual(coupon.siteId, dummySiteID)
     }
 
     /// Verifies that the fields are all parsed correctly
     ///
     func test_CouponsList_map_parses_all_fields_in_result() throws {
-        let coupons = try mapLoadAllCouponsResponse()
-        let coupon = coupons[0]
+        let coupon = try mapRetrieveCouponResponse()
 
         let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
 
@@ -64,8 +57,7 @@ class CouponListMapperTests: XCTestCase {
     /// Verifies that nulls in optional fields are parsed correctly
     ///
     func test_CouponsList_map_accepts_nulls_in_expected_optional_fields() throws {
-        let coupons = try mapLoadMinimalCouponsResponse()
-        let coupon = coupons[0]
+        let coupon = try mapRetrieveMinimalCouponResponse()
 
         let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
 
@@ -98,27 +90,29 @@ class CouponListMapperTests: XCTestCase {
 
 // MARK: - Test Helpers
 ///
-private extension CouponListMapperTests {
+private extension CouponMapperTests {
 
-    /// Returns the CouponListMapper output upon receiving `filename` (Data Encoded)
+    /// Returns the CouponMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapCoupons(from filename: String) throws -> [Coupon] {
+    func mapCoupon(from filename: String) throws -> Coupon {
         guard let response = Loader.contentsOf(filename) else {
-            return []
+            throw FileNotFoundError()
         }
 
-        return try CouponListMapper(siteID: dummySiteID).map(response: response)
+        return try CouponMapper(siteID: dummySiteID).map(response: response)
     }
 
-    /// Returns the CouponsMapper output from `coupons-all.json`
+    /// Returns the CouponMapper output from `coupon.json`
     ///
-    func mapLoadAllCouponsResponse() throws -> [Coupon] {
-        return try mapCoupons(from: "coupons-all")
+    func mapRetrieveCouponResponse() throws -> Coupon {
+        return try mapCoupon(from: "coupon")
     }
 
-    /// Returns the CouponsMapper output from `coupons-minimal.json`
+    /// Returns the CouponMapper output from `coupon-minimal.json`
     ///
-    func mapLoadMinimalCouponsResponse() throws -> [Coupon] {
-        return try mapCoupons(from: "coupons-minimal")
+    func mapRetrieveMinimalCouponResponse() throws -> Coupon {
+        return try mapCoupon(from: "coupon-minimal")
     }
+
+    struct FileNotFoundError: Error {}
 }

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -22,11 +22,11 @@ class CouponsRemoteTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - Load all coupons tests
+    // MARK: - Load all Coupons tests
 
     /// Verifies that loadAllCoupons properly parses the `coupons-all` sample response.
     /// 
-    func test_loadAllCoupons_returns_parsed_coupons() {
+    func test_loadAllCoupons_returns_parsed_coupons() throws {
         // Given
         let remote = CouponsRemote(network: network)
         let expectation = self.expectation(description: "Load All Coupons")
@@ -34,18 +34,19 @@ class CouponsRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
 
         // When
-        var result: (coupons: [Coupon]?, error: Error?)
-        remote.loadAllCoupons(for: sampleSiteID) { coupons, error in
-            result = (coupons, error)
+        var result: Swift.Result<[Coupon], Error>?
+        remote.loadAllCoupons(for: sampleSiteID) { response in
+            result = response
             expectation.fulfill()
         }
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
 
         // Then
-        XCTAssertNil(result.error)
-        XCTAssertNotNil(result.coupons)
-        XCTAssertEqual(result.coupons?.count, 2)
+        XCTAssertFalse(try XCTUnwrap(result).isFailure)
+        let coupons = try XCTUnwrap(result).get()
+        XCTAssertNotNil(coupons)
+        XCTAssertEqual(coupons.count, 2)
     }
 
     /// Verifies that loadAllCoupons uses the passed in parameters to specify the page of results wanted.
@@ -55,7 +56,7 @@ class CouponsRemoteTests: XCTestCase {
         let remote = CouponsRemote(network: network)
 
         // When
-        remote.loadAllCoupons(for: sampleSiteID, pageNumber: 2, pageSize: 17) { _, _ in }
+        remote.loadAllCoupons(for: sampleSiteID, pageNumber: 2, pageSize: 17) { _ in }
 
         // Then
         guard let request = network.requestsForResponseData.first as? JetpackRequest else {
@@ -78,7 +79,7 @@ class CouponsRemoteTests: XCTestCase {
         let remote = CouponsRemote(network: network)
 
         // When
-        remote.loadAllCoupons(for: sampleSiteID) { _, _ in }
+        remote.loadAllCoupons(for: sampleSiteID) { _ in }
 
         // Then
         guard let request = network.requestsForResponseData.first as? JetpackRequest else {
@@ -90,7 +91,7 @@ class CouponsRemoteTests: XCTestCase {
 
     /// Verifies that loadAllCoupons uses the SiteID passed in to build the models.
     ///
-    func test_loadAllCoupons_uses_passed_siteID_for_model_creation() {
+    func test_loadAllCoupons_uses_passed_siteID_for_model_creation() throws {
         // Given
         let remote = CouponsRemote(network: network)
         let expectation = self.expectation(description: "Load All Coupons")
@@ -98,15 +99,16 @@ class CouponsRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
 
         // When
-        var result: (coupons: [Coupon]?, error: Error?)
-        remote.loadAllCoupons(for: sampleSiteID) { coupons, error in
-            result = (coupons, error)
+        var result: Swift.Result<[Coupon], Error>?
+        remote.loadAllCoupons(for: sampleSiteID) { response in
+            result = response
             expectation.fulfill()
         }
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
 
         // Then
-        XCTAssertEqual(result.coupons?.first?.siteId, sampleSiteID)
+        let coupons = try XCTUnwrap(result).get()
+        XCTAssertEqual(coupons.first?.siteId, sampleSiteID)
     }
 }

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import Networking
+import Alamofire
+
+class CouponsRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    ///
+    private var network: MockNetwork!
+
+    /// Dummy Site ID
+    ///
+    private let sampleSiteID: Int64 = 1234
+
+    override func setUp() {
+        super.setUp()
+        network = MockNetwork()
+    }
+
+    override func tearDown() {
+        network = nil
+        super.tearDown()
+    }
+
+    // MARK: - Load all coupons tests
+
+    /// Verifies that loadAllCoupons properly parses the `coupons-all` sample response.
+    /// 
+    func test_loadAllCoupons_returns_parsed_coupons() {
+        // Given
+        let remote = CouponsRemote(network: network)
+        let expectation = self.expectation(description: "Load All Coupons")
+
+        network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
+
+        // When
+        var result: (coupons: [Coupon]?, error: Error?)
+        remote.loadAllCoupons(for: sampleSiteID) { coupons, error in
+            result = (coupons, error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        // Then
+        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.coupons)
+        XCTAssertEqual(result.coupons?.count, 2)
+    }
+
+    /// Verifies that loadAllCoupons uses the passed in parameters to specify the page of results wanted.
+    ///
+    func test_loadAllCoupons_uses_passed_pagination_parameters() throws {
+        // Given
+        let remote = CouponsRemote(network: network)
+
+        // When
+        remote.loadAllCoupons(for: sampleSiteID, pageNumber: 2, pageSize: 17) { _, _ in }
+
+        // Then
+        guard let request = network.requestsForResponseData.first as? JetpackRequest else {
+            XCTFail("Expected request not enqueued")
+            return
+        }
+        guard let page = request.parameters["page"] as? String,
+              let pageSize = request.parameters["per_page"] as? String else {
+            XCTFail("Pagination parameters not found")
+            return
+        }
+        XCTAssertEqual(page, "2")
+        XCTAssertEqual(pageSize, "17")
+    }
+
+    /// Verifies that loadAllCoupons uses the SiteID passed in for the request.
+    ///
+    func test_loadAllCoupons_uses_passed_siteID_for_request() {
+        // Given
+        let remote = CouponsRemote(network: network)
+
+        // When
+        remote.loadAllCoupons(for: sampleSiteID) { _, _ in }
+
+        // Then
+        guard let request = network.requestsForResponseData.first as? JetpackRequest else {
+            XCTFail("Expected request not enqueued")
+            return
+        }
+        XCTAssertEqual(request.siteID, sampleSiteID)
+    }
+
+    /// Verifies that loadAllCoupons uses the SiteID passed in to build the models.
+    ///
+    func test_loadAllCoupons_uses_passed_siteID_for_model_creation() {
+        // Given
+        let remote = CouponsRemote(network: network)
+        let expectation = self.expectation(description: "Load All Coupons")
+
+        network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
+
+        // When
+        var result: (coupons: [Coupon]?, error: Error?)
+        remote.loadAllCoupons(for: sampleSiteID) { coupons, error in
+            result = (coupons, error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        // Then
+        XCTAssertEqual(result.coupons?.first?.siteId, sampleSiteID)
+    }
+}

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -29,23 +29,22 @@ class CouponsRemoteTests: XCTestCase {
     func test_loadAllCoupons_returns_parsed_coupons() throws {
         // Given
         let remote = CouponsRemote(network: network)
-        let expectation = self.expectation(description: "Load All Coupons")
 
         network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
 
         // When
-        var result: Swift.Result<[Coupon], Error>?
-        remote.loadAllCoupons(for: sampleSiteID) { response in
-            result = response
-            expectation.fulfill()
+        let result = waitFor { promise in
+            remote.loadAllCoupons(for: self.sampleSiteID) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
-
         // Then
-        XCTAssertFalse(try XCTUnwrap(result).isFailure)
-        let coupons = try XCTUnwrap(result).get()
-        XCTAssertNotNil(coupons)
+        XCTAssert(result.isSuccess)
+        guard let coupons = try? result.get() else {
+            XCTFail("Expected parsed Coupons not found in response")
+            return
+        }
         XCTAssertEqual(coupons.count, 2)
     }
 
@@ -94,21 +93,18 @@ class CouponsRemoteTests: XCTestCase {
     func test_loadAllCoupons_uses_passed_siteID_for_model_creation() throws {
         // Given
         let remote = CouponsRemote(network: network)
-        let expectation = self.expectation(description: "Load All Coupons")
 
         network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
 
         // When
-        var result: Swift.Result<[Coupon], Error>?
-        remote.loadAllCoupons(for: sampleSiteID) { response in
-            result = response
-            expectation.fulfill()
+        let result = waitFor { promise in
+            remote.loadAllCoupons(for: self.sampleSiteID) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
-
         // Then
-        let coupons = try XCTUnwrap(result).get()
+        let coupons = try result.get()
         XCTAssertEqual(coupons.first?.siteId, sampleSiteID)
     }
 
@@ -146,23 +142,22 @@ class CouponsRemoteTests: XCTestCase {
         // Given
         let remote = CouponsRemote(network: network)
         let sampleCouponID: Int64 = 720
-        let expectation = self.expectation(description: "Delete Coupon")
 
         network.simulateResponse(requestUrlSuffix: "coupons/\(sampleCouponID)", filename: "coupon")
 
         // When
-        var result: Swift.Result<Coupon, Error>?
-        remote.deleteCoupon(for: sampleSiteID, couponID: sampleCouponID) { response in
-            result = response
-            expectation.fulfill()
+        let result = waitFor { promise in
+            remote.deleteCoupon(for: self.sampleSiteID, couponID: sampleCouponID) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
-
         // Then
-        XCTAssertTrue(try XCTUnwrap(result).isSuccess)
-
-        let coupon = try XCTUnwrap(result).get()
+        XCTAssert(result.isSuccess)
+        guard let coupon = try? result.get() else {
+            XCTFail("Expected parsed Coupon not found in response")
+            return
+        }
         XCTAssertEqual(coupon.couponId, sampleCouponID)
     }
 

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -111,4 +111,32 @@ class CouponsRemoteTests: XCTestCase {
         let coupons = try XCTUnwrap(result).get()
         XCTAssertEqual(coupons.first?.siteId, sampleSiteID)
     }
+
+    // MARK: - Delete Coupon tests
+
+    /// Verifies that deleteCoupon properly parses the `coupon` sample response.
+    ///
+    func test_deleteCoupon_properly_returns_parsed_Coupon() throws {
+        // Given
+        let remote = CouponsRemote(network: network)
+        let sampleCouponID: Int64 = 720
+        let expectation = self.expectation(description: "Delete Coupon")
+
+        network.simulateResponse(requestUrlSuffix: "coupons/\(sampleCouponID)", filename: "coupon")
+
+        // When
+        var result: Swift.Result<Coupon, Error>?
+        remote.deleteCoupon(for: sampleSiteID, couponID: sampleCouponID) { response in
+            result = response
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(result).isSuccess)
+
+        let coupon = try XCTUnwrap(result).get()
+        XCTAssertEqual(coupon.couponId, sampleCouponID)
+    }
 }

--- a/Networking/NetworkingTests/Responses/coupon-minimal.json
+++ b/Networking/NetworkingTests/Responses/coupon-minimal.json
@@ -1,0 +1,43 @@
+{
+    "data": {
+        "id": 10714,
+        "code": "test",
+        "amount": "0.00",
+        "date_created": "2021-04-13T08:26:25",
+        "date_created_gmt": "2021-04-13T08:26:25",
+        "date_modified": "2021-04-13T08:26:25",
+        "date_modified_gmt": "2021-04-13T08:26:25",
+        "discount_type": "fixed_cart",
+        "description": "",
+        "date_expires": null,
+        "date_expires_gmt": null,
+        "usage_count": 0,
+        "individual_use": false,
+        "product_ids": [],
+        "excluded_product_ids": [],
+        "usage_limit": null,
+        "usage_limit_per_user": null,
+        "limit_usage_to_x_items": null,
+        "free_shipping": false,
+        "product_categories": [],
+        "excluded_product_categories": [],
+        "exclude_sale_items": false,
+        "minimum_amount": "0.00",
+        "maximum_amount": "0.00",
+        "email_restrictions": [],
+        "used_by": [],
+        "meta_data": [],
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/coupons/720"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/coupons"
+                }
+            ]
+        }
+    }
+}

--- a/Networking/NetworkingTests/Responses/coupon.json
+++ b/Networking/NetworkingTests/Responses/coupon.json
@@ -1,0 +1,43 @@
+{
+    "data": {
+        "id": 720,
+        "code": "free shipping",
+        "amount": "10.00",
+        "date_created": "2017-03-21T15:25:02",
+        "date_created_gmt": "2017-03-21T18:25:02",
+        "date_modified": "2017-03-21T15:25:02",
+        "date_modified_gmt": "2017-03-21T18:25:02",
+        "discount_type": "fixed_cart",
+        "description": "Coupon description",
+        "date_expires": "2017-03-31T15:25:02",
+        "date_expires_gmt": "2017-03-31T18:25:02",
+        "usage_count": 10,
+        "individual_use": true,
+        "product_ids": [12893712, 12389],
+        "excluded_product_ids": [12213],
+        "usage_limit": 1200,
+        "usage_limit_per_user": 3,
+        "limit_usage_to_x_items": 10,
+        "free_shipping": true,
+        "product_categories": [123, 435, 232],
+        "excluded_product_categories": [908],
+        "exclude_sale_items": false,
+        "minimum_amount": "5.00",
+        "maximum_amount": "500.00",
+        "email_restrictions": ["*@a8c.com", "someone.else@example.com"],
+        "used_by": ["someone.else@example.com", "person@a8c.com"],
+        "meta_data": [],
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/coupons/720"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/coupons"
+                }
+            ]
+        }
+    }
+}

--- a/Networking/NetworkingTests/Responses/coupons-all.json
+++ b/Networking/NetworkingTests/Responses/coupons-all.json
@@ -1,0 +1,86 @@
+{
+    "data": [
+        {
+            "id": 720,
+            "code": "free shipping",
+            "amount": "10.00",
+            "date_created": "2017-03-21T15:25:02",
+            "date_created_gmt": "2017-03-21T18:25:02",
+            "date_modified": "2017-03-21T15:25:02",
+            "date_modified_gmt": "2017-03-21T18:25:02",
+            "discount_type": "fixed_cart",
+            "description": "Coupon description",
+            "date_expires": "2017-03-31T15:25:02",
+            "date_expires_gmt": "2017-03-31T18:25:02",
+            "usage_count": 10,
+            "individual_use": true,
+            "product_ids": [12893712, 12389],
+            "excluded_product_ids": [12213],
+            "usage_limit": 1200,
+            "usage_limit_per_user": 3,
+            "limit_usage_to_x_items": 10,
+            "free_shipping": true,
+            "product_categories": [123, 435, 232],
+            "excluded_product_categories": [908],
+            "exclude_sale_items": false,
+            "minimum_amount": "5.00",
+            "maximum_amount": "500.00",
+            "email_restrictions": ["*@a8c.com", "someone.else@example.com"],
+            "used_by": ["someone.else@example.com", "person@a8c.com"],
+            "meta_data": [],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/coupons/720"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/coupons"
+                    }
+                ]
+            }
+        },
+        {
+            "id": 719,
+            "code": "10off",
+            "amount": "10.00",
+            "date_created": "2017-03-21T15:23:00",
+            "date_created_gmt": "2017-03-21T18:23:00",
+            "date_modified": "2017-03-21T15:23:00",
+            "date_modified_gmt": "2017-03-21T18:23:00",
+            "discount_type": "percent",
+            "description": "",
+            "date_expires": null,
+            "date_expires_gmt": null,
+            "usage_count": 0,
+            "individual_use": true,
+            "product_ids": [],
+            "excluded_product_ids": [],
+            "usage_limit": null,
+            "usage_limit_per_user": null,
+            "limit_usage_to_x_items": null,
+            "free_shipping": false,
+            "product_categories": [],
+            "excluded_product_categories": [],
+            "exclude_sale_items": true,
+            "minimum_amount": "100.00",
+            "maximum_amount": "0.00",
+            "email_restrictions": [],
+            "used_by": [],
+            "meta_data": [],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/coupons/719"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/coupons"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Networking/NetworkingTests/Responses/coupons-minimal.json
+++ b/Networking/NetworkingTests/Responses/coupons-minimal.json
@@ -1,0 +1,45 @@
+{
+    "data": [
+        {
+            "id": 10714,
+            "code": "test",
+            "amount": "0.00",
+            "date_created": "2021-04-13T08:26:25",
+            "date_created_gmt": "2021-04-13T08:26:25",
+            "date_modified": "2021-04-13T08:26:25",
+            "date_modified_gmt": "2021-04-13T08:26:25",
+            "discount_type": "fixed_cart",
+            "description": "",
+            "date_expires": null,
+            "date_expires_gmt": null,
+            "usage_count": 0,
+            "individual_use": false,
+            "product_ids": [],
+            "excluded_product_ids": [],
+            "usage_limit": null,
+            "usage_limit_per_user": null,
+            "limit_usage_to_x_items": null,
+            "free_shipping": false,
+            "product_categories": [],
+            "excluded_product_categories": [],
+            "exclude_sale_items": false,
+            "minimum_amount": "0.00",
+            "maximum_amount": "0.00",
+            "email_restrictions": [],
+            "used_by": [],
+            "meta_data": [],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/coupons/720"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/coupons"
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Adds Model, Mappers, and Remote, with endpoints required for the coupon list.

Part of #3912, though to close that task there will be a second PR with the endpoints required for the add/edit coupon screen.

Update release notes:
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
