### PR TITLE
Coupon Management: Networking - Coupon model

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		02E7FFCB256218F600C53030 /* ShippingLabelRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E7FFCA256218F600C53030 /* ShippingLabelRemoteTests.swift */; };
 		02E7FFCF25621C7900C53030 /* shipping-label-print.json in Resources */ = {isa = PBXBuildFile; fileRef = 02E7FFCE25621C7900C53030 /* shipping-label-print.json */; };
 		02F096C22406691100C0C1D5 /* media-library.json in Resources */ = {isa = PBXBuildFile; fileRef = 02F096C12406691100C0C1D5 /* media-library.json */; };
+		03DCB72626244B9B00C8953D /* Coupon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB72526244B9B00C8953D /* Coupon.swift */; };
 		21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */; };
 		24F98C522502E79800F49B68 /* FeatureFlagsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */; };
 		24F98C542502E8DD00F49B68 /* Bundle+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */; };
@@ -508,6 +509,7 @@
 		02E7FFCA256218F600C53030 /* ShippingLabelRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelRemoteTests.swift; sourceTree = "<group>"; };
 		02E7FFCE25621C7900C53030 /* shipping-label-print.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-print.json"; sourceTree = "<group>"; };
 		02F096C12406691100C0C1D5 /* media-library.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-library.json"; sourceTree = "<group>"; };
+		03DCB72526244B9B00C8953D /* Coupon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coupon.swift; sourceTree = "<group>"; };
 		24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsRemote.swift; sourceTree = "<group>"; };
 		24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Woo.swift"; sourceTree = "<group>"; };
 		24F98C552502EA4800F49B68 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
@@ -1275,6 +1277,7 @@
 				B505F6CE20BEE38B00BB1B69 /* Account.swift */,
 				93D8BBFA226BBC5100AD2EB3 /* AccountSettings.swift */,
 				B5BB1D0F20A237FB00112D92 /* Address.swift */,
+				03DCB72526244B9B00C8953D /* Coupon.swift */,
 				B53EF53721813806003E146F /* DotcomError.swift */,
 				24F98C552502EA4800F49B68 /* FeatureFlag.swift */,
 				B5A2417C217F9ECC00595DEF /* MetaContainer.swift */,
@@ -2066,6 +2069,7 @@
 				021C7BF723863D1800A3BCBD /* Encodable+Serialization.swift in Sources */,
 				0219B03923964BB3007DCD5E /* ProductShippingClassMapper.swift in Sources */,
 				7452387321124B7700A973CD /* AnyCodable.swift in Sources */,
+				03DCB72626244B9B00C8953D /* Coupon.swift in Sources */,
 				026CF61E237D6985009563D4 /* ProductVariationListMapper.swift in Sources */,
 				CE43066E2347CBA70073CBFF /* OrderItemTaxRefund.swift in Sources */,
 				26455E2125F66951008A1D32 /* ProductAttributeTerm.swift in Sources */,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -2,6 +2,87 @@
 // DO NOT EDIT
 
 
+extension Coupon {
+    func copy(
+        siteId: CopiableProp<Int64> = .copy,
+        couponId: CopiableProp<Int64> = .copy,
+        code: CopiableProp<String> = .copy,
+        amount: CopiableProp<String> = .copy,
+        dateCreated: CopiableProp<Date> = .copy,
+        dateModified: CopiableProp<Date> = .copy,
+        discountType: CopiableProp<Coupon.DiscountType> = .copy,
+        description: CopiableProp<String> = .copy,
+        dateExpires: NullableCopiableProp<Date> = .copy,
+        usageCount: CopiableProp<Int64> = .copy,
+        individualUse: CopiableProp<Bool> = .copy,
+        productIds: CopiableProp<[Int64]> = .copy,
+        excludedProductIds: CopiableProp<[Int64]> = .copy,
+        usageLimit: NullableCopiableProp<Int64> = .copy,
+        usageLimitPerUser: NullableCopiableProp<Int64> = .copy,
+        limitUsageToXItems: NullableCopiableProp<Int64> = .copy,
+        freeShipping: CopiableProp<Bool> = .copy,
+        productCategories: CopiableProp<[Int64]> = .copy,
+        excludedProductCategories: CopiableProp<[Int64]> = .copy,
+        excludeSaleItems: CopiableProp<Bool> = .copy,
+        minimumAmount: CopiableProp<String> = .copy,
+        maximumAmount: CopiableProp<String> = .copy,
+        emailRestrictions: CopiableProp<[String]> = .copy,
+        usedBy: CopiableProp<[String]> = .copy
+    ) -> Coupon {
+        let siteId = siteId ?? self.siteId
+        let couponId = couponId ?? self.couponId
+        let code = code ?? self.code
+        let amount = amount ?? self.amount
+        let dateCreated = dateCreated ?? self.dateCreated
+        let dateModified = dateModified ?? self.dateModified
+        let discountType = discountType ?? self.discountType
+        let description = description ?? self.description
+        let dateExpires = dateExpires ?? self.dateExpires
+        let usageCount = usageCount ?? self.usageCount
+        let individualUse = individualUse ?? self.individualUse
+        let productIds = productIds ?? self.productIds
+        let excludedProductIds = excludedProductIds ?? self.excludedProductIds
+        let usageLimit = usageLimit ?? self.usageLimit
+        let usageLimitPerUser = usageLimitPerUser ?? self.usageLimitPerUser
+        let limitUsageToXItems = limitUsageToXItems ?? self.limitUsageToXItems
+        let freeShipping = freeShipping ?? self.freeShipping
+        let productCategories = productCategories ?? self.productCategories
+        let excludedProductCategories = excludedProductCategories ?? self.excludedProductCategories
+        let excludeSaleItems = excludeSaleItems ?? self.excludeSaleItems
+        let minimumAmount = minimumAmount ?? self.minimumAmount
+        let maximumAmount = maximumAmount ?? self.maximumAmount
+        let emailRestrictions = emailRestrictions ?? self.emailRestrictions
+        let usedBy = usedBy ?? self.usedBy
+
+        return Coupon(
+            siteId: siteId,
+            couponId: couponId,
+            code: code,
+            amount: amount,
+            dateCreated: dateCreated,
+            dateModified: dateModified,
+            discountType: discountType,
+            description: description,
+            dateExpires: dateExpires,
+            usageCount: usageCount,
+            individualUse: individualUse,
+            productIds: productIds,
+            excludedProductIds: excludedProductIds,
+            usageLimit: usageLimit,
+            usageLimitPerUser: usageLimitPerUser,
+            limitUsageToXItems: limitUsageToXItems,
+            freeShipping: freeShipping,
+            productCategories: productCategories,
+            excludedProductCategories: excludedProductCategories,
+            excludeSaleItems: excludeSaleItems,
+            minimumAmount: minimumAmount,
+            maximumAmount: maximumAmount,
+            emailRestrictions: emailRestrictions,
+            usedBy: usedBy
+        )
+    }
+}
+
 extension Order {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -3,9 +3,9 @@
 
 
 extension Coupon {
-    func copy(
-        siteId: CopiableProp<Int64> = .copy,
-        couponId: CopiableProp<Int64> = .copy,
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        couponID: CopiableProp<Int64> = .copy,
         code: CopiableProp<String> = .copy,
         amount: CopiableProp<String> = .copy,
         dateCreated: CopiableProp<Date> = .copy,
@@ -29,8 +29,8 @@ extension Coupon {
         emailRestrictions: CopiableProp<[String]> = .copy,
         usedBy: CopiableProp<[String]> = .copy
     ) -> Coupon {
-        let siteId = siteId ?? self.siteId
-        let couponId = couponId ?? self.couponId
+        let siteID = siteID ?? self.siteID
+        let couponID = couponID ?? self.couponID
         let code = code ?? self.code
         let amount = amount ?? self.amount
         let dateCreated = dateCreated ?? self.dateCreated
@@ -55,8 +55,8 @@ extension Coupon {
         let usedBy = usedBy ?? self.usedBy
 
         return Coupon(
-            siteId: siteId,
-            couponId: couponId,
+            siteID: siteID,
+            couponID: couponID,
             code: code,
             amount: amount,
             dateCreated: dateCreated,

--- a/Networking/Networking/Model/Coupon.swift
+++ b/Networking/Networking/Model/Coupon.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+
+// MARK: - Coupon
+
+/// Represents a Coupon entity: https://woocommerce.github.io/woocommerce-rest-api-docs/?shell#coupons
+///
+public struct Coupon {
+    /// `siteId` should be set on a copy in the Mapper as it's not returned by the API.
+    /// Using a default here gives us the benefit of synthesised codable conformance.
+    /// `private(set) var` is required so that `siteId` will still be on the synthesised`init` which `copy()` uses
+    private(set) var siteId: Int64 = 0
+    let couponId: Int64
+    /// The coupon code for use at checkout
+    let code: String
+    /// Discount provided by the coupon, used whether the `discountType` is a percentage or fixed amount type.
+    let amount: String
+    /// Date the coupon was created, in GMT (UTC)
+    let dateCreated: Date
+    /// Date the coupon was modified (or created), in GMT (UTC)
+    let dateModified: Date
+    /// Determines the type of discount that will be applied. Options: `.percent` `.fixedCart` and `.fixedProduct`
+    let discountType: DiscountType
+    let description: String
+    /// Date the coupon will expire, in GMT (UTC)
+    let dateExpires: Date?
+    /// Total number of times this coupon has been used, by all customers
+    let usageCount: Int64
+    /// Whether the coupon can only be used alone (`true`) or in conjunction with other coupons (`false`)
+    let individualUse: Bool
+    /// Product IDs of products this coupon can be used against
+    let productIds: [Int64]
+    /// Product IDs of products this coupon cannot be used against
+    let excludedProductIds: [Int64]
+    /// Total number of times this coupon can be used
+    let usageLimit: Int64?
+    /// Number of times this coupon be used per customer
+    let usageLimitPerUser: Int64?
+    /// Maximum number of items which the coupon can be applied to in the cart
+    let limitUsageToXItems: Int64?
+    /// Whether the coupon should provide free shipping
+    let freeShipping: Bool
+    /// Categories which this coupon applies to
+    let productCategories: [Int64]
+    /// Categories which this coupon cannot be used on
+    let excludedProductCategories: [Int64]
+    /// If `true`, this coupon will not be applied to items that have sale prices
+    let excludeSaleItems: Bool
+    /// Minimum order amount that needs to be in the cart before coupon applies
+    let minimumAmount: String
+    /// Maximum order amount allowed when using the coupon
+    let maximumAmount: String
+    /// Email addresses of customers who are allowed to use this coupon, which may include * as wildcard
+    let emailRestrictions: [String]
+    /// Email addresses of customers who have used this coupon
+    let usedBy: [String]
+
+    public enum DiscountType: String {
+        case percent = "percent"
+        case fixedCart = "fixed_cart"
+        case fixedProduct = "fixed_product"
+    }
+}
+
+
+// MARK: - Codable Conformance
+
+/// Defines all of the Coupon CodingKeys
+/// The model is intended to be decoded with`JSONDecoder.KeyDecodingStrategy.convertFromSnakeCase`
+/// so any specific `CodingKeys` provided here should be in camel case.
+extension Coupon: Codable {
+    enum CodingKeys: String, CodingKey {
+        case couponId = "id"
+        case code
+        case amount
+        case dateCreated = "dateCreatedGmt"
+        case dateModified = "dateModifiedGmt"
+        case discountType
+        case description
+        case dateExpires = "dateExpiresGmt"
+        case usageCount
+        case individualUse
+        case productIds
+        case excludedProductIds
+        case usageLimit
+        case usageLimitPerUser
+        case limitUsageToXItems
+        case freeShipping
+        case productCategories
+        case excludedProductCategories
+        case excludeSaleItems
+        case minimumAmount
+        case maximumAmount
+        case emailRestrictions
+        case usedBy
+    }
+}
+
+extension Coupon.DiscountType: Codable {}
+
+
+// MARK: - Other Conformances
+
+extension Coupon: GeneratedCopiable, GeneratedFakeable, Equatable {}
+
+extension Coupon.DiscountType: GeneratedCopiable, GeneratedFakeable, Equatable {}

--- a/Networking/Networking/Model/Coupon.swift
+++ b/Networking/Networking/Model/Coupon.swift
@@ -6,54 +6,54 @@ import Foundation
 /// Represents a Coupon entity: https://woocommerce.github.io/woocommerce-rest-api-docs/?shell#coupons
 ///
 public struct Coupon {
-    /// `siteId` should be set on a copy in the Mapper as it's not returned by the API.
+    /// `siteID` should be set on a copy in the Mapper as it's not returned by the API.
     /// Using a default here gives us the benefit of synthesised codable conformance.
-    /// `private(set) var` is required so that `siteId` will still be on the synthesised`init` which `copy()` uses
-    private(set) var siteId: Int64 = 0
-    let couponId: Int64
+    /// `private(set) public var` is required so that `siteID` will still be on the synthesised`init` which `copy()` uses
+    private(set) public var siteID: Int64 = 0
+    public let couponID: Int64
     /// The coupon code for use at checkout
-    let code: String
+    public let code: String
     /// Discount provided by the coupon, used whether the `discountType` is a percentage or fixed amount type.
-    let amount: String
+    public let amount: String
     /// Date the coupon was created, in GMT (UTC)
-    let dateCreated: Date
+    public let dateCreated: Date
     /// Date the coupon was modified (or created), in GMT (UTC)
-    let dateModified: Date
+    public let dateModified: Date
     /// Determines the type of discount that will be applied. Options: `.percent` `.fixedCart` and `.fixedProduct`
-    let discountType: DiscountType
-    let description: String
+    public let discountType: DiscountType
+    public let description: String
     /// Date the coupon will expire, in GMT (UTC)
-    let dateExpires: Date?
+    public let dateExpires: Date?
     /// Total number of times this coupon has been used, by all customers
-    let usageCount: Int64
+    public let usageCount: Int64
     /// Whether the coupon can only be used alone (`true`) or in conjunction with other coupons (`false`)
-    let individualUse: Bool
+    public let individualUse: Bool
     /// Product IDs of products this coupon can be used against
-    let productIds: [Int64]
+    public let productIds: [Int64]
     /// Product IDs of products this coupon cannot be used against
-    let excludedProductIds: [Int64]
+    public let excludedProductIds: [Int64]
     /// Total number of times this coupon can be used
-    let usageLimit: Int64?
+    public let usageLimit: Int64?
     /// Number of times this coupon be used per customer
-    let usageLimitPerUser: Int64?
+    public let usageLimitPerUser: Int64?
     /// Maximum number of items which the coupon can be applied to in the cart
-    let limitUsageToXItems: Int64?
+    public let limitUsageToXItems: Int64?
     /// Whether the coupon should provide free shipping
-    let freeShipping: Bool
+    public let freeShipping: Bool
     /// Categories which this coupon applies to
-    let productCategories: [Int64]
+    public let productCategories: [Int64]
     /// Categories which this coupon cannot be used on
-    let excludedProductCategories: [Int64]
+    public let excludedProductCategories: [Int64]
     /// If `true`, this coupon will not be applied to items that have sale prices
-    let excludeSaleItems: Bool
+    public let excludeSaleItems: Bool
     /// Minimum order amount that needs to be in the cart before coupon applies
-    let minimumAmount: String
+    public let minimumAmount: String
     /// Maximum order amount allowed when using the coupon
-    let maximumAmount: String
+    public let maximumAmount: String
     /// Email addresses of customers who are allowed to use this coupon, which may include * as wildcard
-    let emailRestrictions: [String]
+    public let emailRestrictions: [String]
     /// Email addresses of customers who have used this coupon
-    let usedBy: [String]
+    public let usedBy: [String]
 
     public enum DiscountType: String {
         case percent = "percent"
@@ -70,7 +70,7 @@ public struct Coupon {
 /// so any specific `CodingKeys` provided here should be in camel case.
 extension Coupon: Codable {
     enum CodingKeys: String, CodingKey {
-        case couponId = "id"
+        case couponID = "id"
         case code
         case amount
         case dateCreated = "dateCreatedGmt"

--- a/Networking/Networking/Model/Coupon.swift
+++ b/Networking/Networking/Model/Coupon.swift
@@ -10,48 +10,71 @@ public struct Coupon {
     /// Using a default here gives us the benefit of synthesised codable conformance.
     /// `private(set) public var` is required so that `siteID` will still be on the synthesised`init` which `copy()` uses
     private(set) public var siteID: Int64 = 0
+    
     public let couponID: Int64
+    
     /// The coupon code for use at checkout
     public let code: String
+    
     /// Discount provided by the coupon, used whether the `discountType` is a percentage or fixed amount type.
     public let amount: String
+    
     /// Date the coupon was created, in GMT (UTC)
     public let dateCreated: Date
+    
     /// Date the coupon was modified (or created), in GMT (UTC)
     public let dateModified: Date
+    
     /// Determines the type of discount that will be applied. Options: `.percent` `.fixedCart` and `.fixedProduct`
     public let discountType: DiscountType
+    
     public let description: String
+    
     /// Date the coupon will expire, in GMT (UTC)
     public let dateExpires: Date?
+    
     /// Total number of times this coupon has been used, by all customers
     public let usageCount: Int64
+    
     /// Whether the coupon can only be used alone (`true`) or in conjunction with other coupons (`false`)
     public let individualUse: Bool
+    
     /// Product IDs of products this coupon can be used against
     public let productIds: [Int64]
+    
     /// Product IDs of products this coupon cannot be used against
     public let excludedProductIds: [Int64]
+    
     /// Total number of times this coupon can be used
     public let usageLimit: Int64?
+    
     /// Number of times this coupon be used per customer
     public let usageLimitPerUser: Int64?
+    
     /// Maximum number of items which the coupon can be applied to in the cart
     public let limitUsageToXItems: Int64?
+    
     /// Whether the coupon should provide free shipping
     public let freeShipping: Bool
+    
     /// Categories which this coupon applies to
     public let productCategories: [Int64]
+    
     /// Categories which this coupon cannot be used on
     public let excludedProductCategories: [Int64]
+    
     /// If `true`, this coupon will not be applied to items that have sale prices
     public let excludeSaleItems: Bool
+    
     /// Minimum order amount that needs to be in the cart before coupon applies
     public let minimumAmount: String
+    
     /// Maximum order amount allowed when using the coupon
     public let maximumAmount: String
+    
     /// Email addresses of customers who are allowed to use this coupon, which may include * as wildcard
     public let emailRestrictions: [String]
+    
     /// Email addresses of customers who have used this coupon
     public let usedBy: [String]
 

--- a/Networking/Networking/Model/Coupon.swift
+++ b/Networking/Networking/Model/Coupon.swift
@@ -10,71 +10,71 @@ public struct Coupon {
     /// Using a default here gives us the benefit of synthesised codable conformance.
     /// `private(set) public var` is required so that `siteID` will still be on the synthesised`init` which `copy()` uses
     private(set) public var siteID: Int64 = 0
-    
+
     public let couponID: Int64
-    
+
     /// The coupon code for use at checkout
     public let code: String
-    
+
     /// Discount provided by the coupon, used whether the `discountType` is a percentage or fixed amount type.
     public let amount: String
-    
+
     /// Date the coupon was created, in GMT (UTC)
     public let dateCreated: Date
-    
+
     /// Date the coupon was modified (or created), in GMT (UTC)
     public let dateModified: Date
-    
+
     /// Determines the type of discount that will be applied. Options: `.percent` `.fixedCart` and `.fixedProduct`
     public let discountType: DiscountType
-    
+
     public let description: String
-    
+
     /// Date the coupon will expire, in GMT (UTC)
     public let dateExpires: Date?
-    
+
     /// Total number of times this coupon has been used, by all customers
     public let usageCount: Int64
-    
+
     /// Whether the coupon can only be used alone (`true`) or in conjunction with other coupons (`false`)
     public let individualUse: Bool
-    
+
     /// Product IDs of products this coupon can be used against
     public let productIds: [Int64]
-    
+
     /// Product IDs of products this coupon cannot be used against
     public let excludedProductIds: [Int64]
-    
+
     /// Total number of times this coupon can be used
     public let usageLimit: Int64?
-    
+
     /// Number of times this coupon be used per customer
     public let usageLimitPerUser: Int64?
-    
+
     /// Maximum number of items which the coupon can be applied to in the cart
     public let limitUsageToXItems: Int64?
-    
+
     /// Whether the coupon should provide free shipping
     public let freeShipping: Bool
-    
+
     /// Categories which this coupon applies to
     public let productCategories: [Int64]
-    
+
     /// Categories which this coupon cannot be used on
     public let excludedProductCategories: [Int64]
-    
+
     /// If `true`, this coupon will not be applied to items that have sale prices
     public let excludeSaleItems: Bool
-    
+
     /// Minimum order amount that needs to be in the cart before coupon applies
     public let minimumAmount: String
-    
+
     /// Maximum order amount allowed when using the coupon
     public let maximumAmount: String
-    
+
     /// Email addresses of customers who are allowed to use this coupon, which may include * as wildcard
     public let emailRestrictions: [String]
-    
+
     /// Email addresses of customers who have used this coupon
     public let usedBy: [String]
 


### PR DESCRIPTION
Part of #3912

## Description
Adds the Coupon model according to the API docs, except for a few fields which would add confusion and are unlikely to be required, e.g. the dates in the site’s timezone.

Synthesised `Codable` conformance is used as far as possible, which gives us more compiler-provided safety, e.g. around key decoding correctness. Overrides for keys are only given where they're strictly required, and they're in camel case rather than snake case to support using a decoder set to `.convertFromSnakeCase`.

`siteId` is a `private(set) var`, rather than a `let` as we would ideally like. This is required so that we can inject the `siteId` in the mapper, while still benefitting from the synthesised `decode` method. Injection in the mapper will be done via `.copy()`, not mutation, and future improvements in Swift may eventually let us make this a `let` again.

I'll put full details of this approach in a P2 and link to it from here, as it is a slight departure from the established convention. I think that doing it this way would make us less likely to make mistakes while writing model property names out in slightly different ways in several places through the file and tests.

## Testing
The model is not in use yet, so no applicable testing other than the unit tests, and CI once it's merged to the main repo.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
