### PR TITLE
Coupon Management: Networking - Remote with loadAllCoupons endpoint method

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -72,7 +72,6 @@
 		03DCB7402624AD7D00C8953D /* CouponListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */; };
 		03DCB7442624AD9B00C8953D /* CouponListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */; };
 		03DCB7522624B3BE00C8953D /* coupons-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 03DCB7512624B3BE00C8953D /* coupons-all.json */; };
-		03DCB76426258CA200C8953D /* coupons-minimal.json in Resources */ = {isa = PBXBuildFile; fileRef = 03DCB76326258CA200C8953D /* coupons-minimal.json */; };
 		03DCB76C262591C400C8953D /* CouponsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB76B262591C400C8953D /* CouponsRemoteTests.swift */; };
 		03DCB772262591D900C8953D /* CouponsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB771262591D900C8953D /* CouponsRemote.swift */; };
 		21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */; };

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -72,6 +72,9 @@
 		03DCB7402624AD7D00C8953D /* CouponListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */; };
 		03DCB7442624AD9B00C8953D /* CouponListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */; };
 		03DCB7522624B3BE00C8953D /* coupons-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 03DCB7512624B3BE00C8953D /* coupons-all.json */; };
+		03DCB76426258CA200C8953D /* coupons-minimal.json in Resources */ = {isa = PBXBuildFile; fileRef = 03DCB76326258CA200C8953D /* coupons-minimal.json */; };
+		03DCB76C262591C400C8953D /* CouponsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB76B262591C400C8953D /* CouponsRemoteTests.swift */; };
+		03DCB772262591D900C8953D /* CouponsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB771262591D900C8953D /* CouponsRemote.swift */; };
 		21DB5B99C4107CF69C0A57EC /* Pods_NetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69314EDE650855CAF927057E /* Pods_NetworkingTests.framework */; };
 		24F98C522502E79800F49B68 /* FeatureFlagsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */; };
 		24F98C542502E8DD00F49B68 /* Bundle+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */; };
@@ -522,6 +525,8 @@
 		03DCB73F2624AD7D00C8953D /* CouponListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListMapper.swift; sourceTree = "<group>"; };
 		03DCB7432624AD9A00C8953D /* CouponListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponListMapperTests.swift; sourceTree = "<group>"; };
 		03DCB7512624B3BE00C8953D /* coupons-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupons-all.json"; sourceTree = "<group>"; };
+		03DCB76B262591C400C8953D /* CouponsRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponsRemoteTests.swift; sourceTree = "<group>"; };
+		03DCB771262591D900C8953D /* CouponsRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouponsRemote.swift; sourceTree = "<group>"; };
 		24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagsRemote.swift; sourceTree = "<group>"; };
 		24F98C532502E8DD00F49B68 /* Bundle+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Woo.swift"; sourceTree = "<group>"; };
 		24F98C552502EA4800F49B68 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
@@ -1108,6 +1113,7 @@
 				B505F6D620BEE58800BB1B69 /* AccountRemoteTests.swift */,
 				93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */,
 				740211E021939908002248DA /* CommentRemoteTests.swift */,
+				03DCB76B262591C400C8953D /* CouponsRemoteTests.swift */,
 				B524194821AC659500D6FC0A /* DevicesRemoteTests.swift */,
 				24F98C5F2502EF8200F49B68 /* FeatureFlagRemoteTests.swift */,
 				26B2F74824C55ACE0065CCC8 /* LeaderboardsRemoteTests.swift */,
@@ -1229,6 +1235,7 @@
 				B557DA0020975500005962F4 /* Remote.swift */,
 				B505F6D020BEE39600BB1B69 /* AccountRemote.swift */,
 				740CF89821937A030023ED3A /* CommentRemote.swift */,
+				03DCB771262591D900C8953D /* CouponsRemote.swift */,
 				B572F69921AC475C003EEFF0 /* DevicesRemote.swift */,
 				24F98C512502E79800F49B68 /* FeatureFlagsRemote.swift */,
 				26B2F74024C1F2C10065CCC8 /* LeaderboardsRemote.swift */,
@@ -2030,6 +2037,7 @@
 				457453E725A72C9700276508 /* CreateProductVariation.swift in Sources */,
 				B505F6EA20BEFC3700BB1B69 /* MockNetwork.swift in Sources */,
 				CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */,
+				03DCB772262591D900C8953D /* CouponsRemote.swift in Sources */,
 				CE6BFEE52236BF05005C79FB /* Product.swift in Sources */,
 				5726F159248E9D88005AE9B4 /* Models+Copiable.generated.swift in Sources */,
 				7452387221124B7700A973CD /* AnyEncodable.swift in Sources */,
@@ -2284,6 +2292,7 @@
 				B554FA932180C17200C54DFF /* NoteHashListMapperTests.swift in Sources */,
 				74002D6A2118B26100A63C19 /* SiteVisitStatsMapperTests.swift in Sources */,
 				743E84FA221742E300FAC9D7 /* ShipmentsRemoteTests.swift in Sources */,
+				03DCB76C262591C400C8953D /* CouponsRemoteTests.swift in Sources */,
 				743E84F822172E1F00FAC9D7 /* ShipmentTrackingListMapperTests.swift in Sources */,
 				45ED4F14239E8F2E004F1BE3 /* TaxClassRemoteTests.swift in Sources */,
 				D88D5A4D230BD010007B6E01 /* ProductReviewsRemoteTests.swift in Sources */,

--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Coupons: Remote endpoints
+///
+public final class CouponsRemote: Remote {
+    // MARK: - Coupons
+
+    /// Retrieves all of the `Coupon`s from the API.
+    ///
+    /// - Parameters:
+    ///     - siteID
+    ///     - pageNumber:
+    ///     - pageSize:
+    ///     - completion:
+    ///
+    public func loadAllCoupons(for siteID: Int64,
+                               pageNumber: Int = Default.pageNumber,
+                               pageSize: Int = Default.pageSize,
+                               completion: @escaping ([Coupon]?, Error?) -> ()) {
+        let parameters = [
+            ParameterKey.page: String(pageNumber),
+            ParameterKey.perPage: String(pageSize)
+        ]
+
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: Path.coupons,
+                                     parameters: parameters)
+
+        let mapper = CouponListMapper(siteID: siteID)
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+}
+
+// MARK: - Constants
+//
+public extension CouponsRemote {
+    enum Default {
+        public static let pageSize: Int = 25
+        public static let pageNumber: Int = 1
+    }
+
+    private enum Path {
+        static let coupons = "coupons"
+    }
+
+    private enum ParameterKey {
+        static let page: String = "page"
+        static let perPage: String = "per_page"
+    }
+}

--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Coupons: Remote endpoints
 ///
 public final class CouponsRemote: Remote {
-    // MARK: - Coupons
+    // MARK: - Get Coupons
 
     /// Retrieves all of the `Coupon`s from the API.
     ///
@@ -16,7 +16,7 @@ public final class CouponsRemote: Remote {
     public func loadAllCoupons(for siteID: Int64,
                                pageNumber: Int = Default.pageNumber,
                                pageSize: Int = Default.pageSize,
-                               completion: @escaping ([Coupon]?, Error?) -> ()) {
+                               completion: @escaping (Result<[Coupon], Error>) -> ()) {
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize)
@@ -38,8 +38,8 @@ public final class CouponsRemote: Remote {
 //
 public extension CouponsRemote {
     enum Default {
-        public static let pageSize: Int = 25
-        public static let pageNumber: Int = 1
+        public static let pageSize = 25
+        public static let pageNumber = 1
     }
 
     private enum Path {
@@ -47,7 +47,7 @@ public extension CouponsRemote {
     }
 
     private enum ParameterKey {
-        static let page: String = "page"
-        static let perPage: String = "per_page"
+        static let page = "page"
+        static let perPage = "per_page"
     }
 }

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import Networking
+import Alamofire
+
+class CouponsRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    ///
+    private var network: MockNetwork!
+
+    /// Dummy Site ID
+    ///
+    private let sampleSiteID: Int64 = 1234
+
+    override func setUp() {
+        super.setUp()
+        network = MockNetwork()
+    }
+
+    override func tearDown() {
+        network = nil
+        super.tearDown()
+    }
+
+    // MARK: - Load all coupons tests
+
+    /// Verifies that loadAllCoupons properly parses the `coupons-all` sample response.
+    /// 
+    func test_loadAllCoupons_returns_parsed_coupons() {
+        // Given
+        let remote = CouponsRemote(network: network)
+        let expectation = self.expectation(description: "Load All Coupons")
+
+        network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
+
+        // When
+        var result: (coupons: [Coupon]?, error: Error?)
+        remote.loadAllCoupons(for: sampleSiteID) { coupons, error in
+            result = (coupons, error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        // Then
+        XCTAssertNil(result.error)
+        XCTAssertNotNil(result.coupons)
+        XCTAssertEqual(result.coupons?.count, 3)
+    }
+
+    /// Verifies that loadAllCoupons uses the passed in parameters to specify the page of results wanted.
+    ///
+    func test_loadAllCoupons_uses_passed_pagination_parameters() throws {
+        // Given
+        let remote = CouponsRemote(network: network)
+
+        // When
+        remote.loadAllCoupons(for: sampleSiteID, pageNumber: 2, pageSize: 17) { _, _ in }
+
+        // Then
+        guard let request = network.requestsForResponseData.first as? JetpackRequest else {
+            XCTFail("Expected request not enqueued")
+            return
+        }
+        guard let page = request.parameters["page"] as? String,
+              let pageSize = request.parameters["per_page"] as? String else {
+            XCTFail("Pagination parameters not found")
+            return
+        }
+        XCTAssertEqual(page, "2")
+        XCTAssertEqual(pageSize, "17")
+    }
+
+    /// Verifies that loadAllCoupons uses the SiteID passed in for the request.
+    ///
+    func test_loadAllCoupons_uses_passed_siteID_for_request() {
+        // Given
+        let remote = CouponsRemote(network: network)
+
+        // When
+        remote.loadAllCoupons(for: sampleSiteID) { _, _ in }
+
+        // Then
+        guard let request = network.requestsForResponseData.first as? JetpackRequest else {
+            XCTFail("Expected request not enqueued")
+            return
+        }
+        XCTAssertEqual(request.siteID, sampleSiteID)
+    }
+
+    /// Verifies that loadAllCoupons uses the SiteID passed in to build the models.
+    ///
+    func test_loadAllCoupons_uses_passed_siteID_for_model_creation() {
+        // Given
+        let remote = CouponsRemote(network: network)
+        let expectation = self.expectation(description: "Load All Coupons")
+
+        network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
+
+        // When
+        var result: (coupons: [Coupon]?, error: Error?)
+        remote.loadAllCoupons(for: sampleSiteID) { coupons, error in
+            result = (coupons, error)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: Constants.expectationTimeout)
+
+        // Then
+        XCTAssertEqual(result.coupons?.first?.siteId, sampleSiteID)
+    }
+}

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -22,11 +22,11 @@ class CouponsRemoteTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - Load all coupons tests
+    // MARK: - Load all Coupons tests
 
     /// Verifies that loadAllCoupons properly parses the `coupons-all` sample response.
     /// 
-    func test_loadAllCoupons_returns_parsed_coupons() {
+    func test_loadAllCoupons_returns_parsed_coupons() throws {
         // Given
         let remote = CouponsRemote(network: network)
         let expectation = self.expectation(description: "Load All Coupons")
@@ -34,18 +34,19 @@ class CouponsRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
 
         // When
-        var result: (coupons: [Coupon]?, error: Error?)
-        remote.loadAllCoupons(for: sampleSiteID) { coupons, error in
-            result = (coupons, error)
+        var result: Swift.Result<[Coupon], Error>?
+        remote.loadAllCoupons(for: sampleSiteID) { response in
+            result = response
             expectation.fulfill()
         }
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
 
         // Then
-        XCTAssertNil(result.error)
-        XCTAssertNotNil(result.coupons)
-        XCTAssertEqual(result.coupons?.count, 3)
+        XCTAssertFalse(try XCTUnwrap(result).isFailure)
+        let coupons = try XCTUnwrap(result).get()
+        XCTAssertNotNil(coupons)
+        XCTAssertEqual(coupons.count, 3)
     }
 
     /// Verifies that loadAllCoupons uses the passed in parameters to specify the page of results wanted.
@@ -55,7 +56,7 @@ class CouponsRemoteTests: XCTestCase {
         let remote = CouponsRemote(network: network)
 
         // When
-        remote.loadAllCoupons(for: sampleSiteID, pageNumber: 2, pageSize: 17) { _, _ in }
+        remote.loadAllCoupons(for: sampleSiteID, pageNumber: 2, pageSize: 17) { _ in }
 
         // Then
         guard let request = network.requestsForResponseData.first as? JetpackRequest else {
@@ -78,7 +79,7 @@ class CouponsRemoteTests: XCTestCase {
         let remote = CouponsRemote(network: network)
 
         // When
-        remote.loadAllCoupons(for: sampleSiteID) { _, _ in }
+        remote.loadAllCoupons(for: sampleSiteID) { _ in }
 
         // Then
         guard let request = network.requestsForResponseData.first as? JetpackRequest else {
@@ -90,7 +91,7 @@ class CouponsRemoteTests: XCTestCase {
 
     /// Verifies that loadAllCoupons uses the SiteID passed in to build the models.
     ///
-    func test_loadAllCoupons_uses_passed_siteID_for_model_creation() {
+    func test_loadAllCoupons_uses_passed_siteID_for_model_creation() throws {
         // Given
         let remote = CouponsRemote(network: network)
         let expectation = self.expectation(description: "Load All Coupons")
@@ -98,15 +99,16 @@ class CouponsRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
 
         // When
-        var result: (coupons: [Coupon]?, error: Error?)
-        remote.loadAllCoupons(for: sampleSiteID) { coupons, error in
-            result = (coupons, error)
+        var result: Swift.Result<[Coupon], Error>?
+        remote.loadAllCoupons(for: sampleSiteID) { response in
+            result = response
             expectation.fulfill()
         }
 
         wait(for: [expectation], timeout: Constants.expectationTimeout)
 
         // Then
-        XCTAssertEqual(result.coupons?.first?.siteId, sampleSiteID)
+        let coupons = try XCTUnwrap(result).get()
+        XCTAssertEqual(coupons.first?.siteId, sampleSiteID)
     }
 }

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -105,7 +105,7 @@ class CouponsRemoteTests: XCTestCase {
 
         // Then
         let coupons = try result.get()
-        XCTAssertEqual(coupons.first?.siteId, sampleSiteID)
+        XCTAssertEqual(coupons.first?.siteID, sampleSiteID)
     }
 
     /// Verifies that loadAllCoupons properly relays Networking Layer errors.

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -29,23 +29,22 @@ class CouponsRemoteTests: XCTestCase {
     func test_loadAllCoupons_returns_parsed_coupons() throws {
         // Given
         let remote = CouponsRemote(network: network)
-        let expectation = self.expectation(description: "Load All Coupons")
 
         network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
 
         // When
-        var result: Swift.Result<[Coupon], Error>?
-        remote.loadAllCoupons(for: sampleSiteID) { response in
-            result = response
-            expectation.fulfill()
+        let result = waitFor { promise in
+            remote.loadAllCoupons(for: self.sampleSiteID) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
-
         // Then
-        XCTAssertFalse(try XCTUnwrap(result).isFailure)
-        let coupons = try XCTUnwrap(result).get()
-        XCTAssertNotNil(coupons)
+        XCTAssert(result.isSuccess)
+        guard let coupons = try? result.get() else {
+            XCTFail("Expected parsed Coupons not found in response")
+            return
+        }
         XCTAssertEqual(coupons.count, 3)
     }
 
@@ -94,21 +93,18 @@ class CouponsRemoteTests: XCTestCase {
     func test_loadAllCoupons_uses_passed_siteID_for_model_creation() throws {
         // Given
         let remote = CouponsRemote(network: network)
-        let expectation = self.expectation(description: "Load All Coupons")
 
         network.simulateResponse(requestUrlSuffix: "coupons", filename: "coupons-all")
 
         // When
-        var result: Swift.Result<[Coupon], Error>?
-        remote.loadAllCoupons(for: sampleSiteID) { response in
-            result = response
-            expectation.fulfill()
+        let result = waitFor { promise in
+            remote.loadAllCoupons(for: self.sampleSiteID) { result in
+                promise(result)
+            }
         }
 
-        wait(for: [expectation], timeout: Constants.expectationTimeout)
-
         // Then
-        let coupons = try XCTUnwrap(result).get()
+        let coupons = try result.get()
         XCTAssertEqual(coupons.first?.siteId, sampleSiteID)
     }
 

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -1,8 +1,7 @@
 import XCTest
 @testable import Networking
-import Alamofire
 
-class CouponsRemoteTests: XCTestCase {
+final class CouponsRemoteTests: XCTestCase {
 
     /// Dummy Network Wrapper
     ///

--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		02DA64172313C26400284168 /* StatsVersionBySite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DA64162313C26400284168 /* StatsVersionBySite.swift */; };
 		02DA64192313C2AA00284168 /* StatsVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DA64182313C2AA00284168 /* StatsVersion.swift */; };
 		02EAB6D72480A86D00FD873C /* CrashLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EAB6D62480A86D00FD873C /* CrashLogger.swift */; };
+		03DCB80F2629AFE700C8953D /* Coupon+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB80D2629AFE700C8953D /* Coupon+CoreDataClass.swift */; };
+		03DCB8102629AFE700C8953D /* Coupon+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03DCB80E2629AFE700C8953D /* Coupon+CoreDataProperties.swift */; };
 		2618707325409C65006522A1 /* ShippingLineTax+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618707125409C65006522A1 /* ShippingLineTax+CoreDataClass.swift */; };
 		2618707425409C65006522A1 /* ShippingLineTax+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2618707225409C65006522A1 /* ShippingLineTax+CoreDataProperties.swift */; };
 		2619F71925AF95030006DAFF /* StorageTypeExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2619F71825AF95020006DAFF /* StorageTypeExtensionsTests.swift */; };
@@ -233,6 +235,9 @@
 		02DA64182313C2AA00284168 /* StatsVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsVersion.swift; sourceTree = "<group>"; };
 		02E4F5E223CD552F003B0010 /* Model 26.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 26.xcdatamodel"; sourceTree = "<group>"; };
 		02EAB6D62480A86D00FD873C /* CrashLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLogger.swift; sourceTree = "<group>"; };
+		03DCB80C2629ACFA00C8953D /* Model 48.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 48.xcdatamodel"; sourceTree = "<group>"; };
+		03DCB80D2629AFE700C8953D /* Coupon+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Coupon+CoreDataClass.swift"; sourceTree = "<group>"; };
+		03DCB80E2629AFE700C8953D /* Coupon+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Coupon+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		261870702540944C006522A1 /* Model 34.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 34.xcdatamodel"; sourceTree = "<group>"; };
 		2618707125409C65006522A1 /* ShippingLineTax+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLineTax+CoreDataClass.swift"; sourceTree = "<group>"; };
 		2618707225409C65006522A1 /* ShippingLineTax+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShippingLineTax+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -710,6 +715,8 @@
 				B59E11D820A9D00C004121A4 /* WooCommerce.xcdatamodeld */,
 				B505F6D920BEEA3200BB1B69 /* Account+CoreDataClass.swift */,
 				B505F6D820BEEA3100BB1B69 /* Account+CoreDataProperties.swift */,
+				03DCB80D2629AFE700C8953D /* Coupon+CoreDataClass.swift */,
+				03DCB80E2629AFE700C8953D /* Coupon+CoreDataProperties.swift */,
 				455C0C8E25DD6D93007B6F38 /* AccountSettings+CoreDataClass.swift */,
 				455C0C8F25DD6D93007B6F38 /* AccountSettings+CoreDataProperties.swift */,
 				74F009BE2183B99B002B4566 /* Note+CoreDataClass.swift */,
@@ -1125,6 +1132,7 @@
 				74F009C02183B99B002B4566 /* Note+CoreDataClass.swift in Sources */,
 				7499FA44221C7A60004EC0B4 /* ShipmentTracking+CoreDataClass.swift in Sources */,
 				D87F61532265AA230031A13B /* FileStorage.swift in Sources */,
+				03DCB80F2629AFE700C8953D /* Coupon+CoreDataClass.swift in Sources */,
 				CE4FD4482350EB7600A16B31 /* OrderItemRefund+CoreDataProperties.swift in Sources */,
 				D8FBFF5622D66A06006E3336 /* OrderStatsV4Interval+CoreDataProperties.swift in Sources */,
 				261CF1C4255B291F0090D8D3 /* PaymentGateway+CoreDataClass.swift in Sources */,
@@ -1135,6 +1143,7 @@
 				7492FAD7217FA9C100ED2C69 /* SiteSetting+CoreDataProperties.swift in Sources */,
 				45E1863023704519009241F3 /* ShippingLine+CoreDataProperties.swift in Sources */,
 				B5FD111F21D4046E00560344 /* OrderSearchResults+CoreDataClass.swift in Sources */,
+				03DCB8102629AFE700C8953D /* Coupon+CoreDataProperties.swift in Sources */,
 				02C254EE2563B12E00A04423 /* ShippingLabel+CoreDataProperties.swift in Sources */,
 				D8550D02230D3F8B00AAC4F8 /* ProductReview+CoreDataProperties.swift in Sources */,
 				9302E3A6220DC3AE00DA5018 /* CoreDataIterativeMigrator.swift in Sources */,
@@ -1577,6 +1586,7 @@
 		B59E11D820A9D00C004121A4 /* WooCommerce.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				03DCB80C2629ACFA00C8953D /* Model 48.xcdatamodel */,
 				266503372620D44C0079A159 /* Model 47.xcdatamodel */,
 				CCD2E70525DE995900BD975D /* Model 46.xcdatamodel */,
 				455C0C8325DD6C2B007B6F38 /* Model 45.xcdatamodel */,
@@ -1625,7 +1635,7 @@
 				746A9D14214071F90013F6FF /* Model 2.xcdatamodel */,
 				B59E11D920A9D00C004121A4 /* Model.xcdatamodel */,
 			);
-			currentVersion = 266503372620D44C0079A159 /* Model 47.xcdatamodel */;
+			currentVersion = 03DCB80C2629ACFA00C8953D /* Model 48.xcdatamodel */;
 			path = WooCommerce.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;

--- a/Storage/Storage/Model/Coupon+CoreDataClass.swift
+++ b/Storage/Storage/Model/Coupon+CoreDataClass.swift
@@ -1,0 +1,7 @@
+import Foundation
+import CoreData
+
+@objc(Coupon)
+public class Coupon: NSManagedObject {
+
+}

--- a/Storage/Storage/Model/Coupon+CoreDataProperties.swift
+++ b/Storage/Storage/Model/Coupon+CoreDataProperties.swift
@@ -1,0 +1,108 @@
+import Foundation
+import CoreData
+
+
+extension Coupon {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Coupon> {
+        return NSFetchRequest<Coupon>(entityName: "Coupon")
+    }
+
+    @NSManaged public var siteID: Int64
+    @NSManaged public var couponID: Int64
+    @NSManaged public var code: String?
+    @NSManaged public var amount: String?
+    @NSManaged public var dateCreated: Date?
+    @NSManaged public var dateModified: Date?
+    @NSManaged public var discountType: String?
+    @NSManaged public var fullDescription: String?
+    @NSManaged public var dateExpires: Date?
+    @NSManaged public var usageCount: Int64
+    @NSManaged public var individualUse: Bool
+    @NSManaged public var usageLimit: Int64
+    @NSManaged public var usageLimitPerUser: Int64
+    @NSManaged public var limitUsageToXItems: Int64
+    @NSManaged public var freeShipping: Bool
+    @NSManaged public var excludeSaleItems: Bool
+    @NSManaged public var minimumAmount: String?
+    @NSManaged public var maximumAmount: String?
+    @NSManaged public var emailRestrictions: [String]?
+    @NSManaged public var usedBy: [String]?
+    @NSManaged public var products: Set<Product>?
+    @NSManaged public var excludedProducts: Set<Product>?
+    @NSManaged public var productCategories: Set<ProductCategory>?
+    @NSManaged public var excludedProductCategories: Set<ProductCategory>?
+
+}
+
+// MARK: Generated accessors for products
+extension Coupon {
+
+    @objc(addProductsObject:)
+    @NSManaged public func addToProducts(_ value: Product)
+
+    @objc(removeProductsObject:)
+    @NSManaged public func removeFromProducts(_ value: Product)
+
+    @objc(addProducts:)
+    @NSManaged public func addToProducts(_ values: NSSet)
+
+    @objc(removeProducts:)
+    @NSManaged public func removeFromProducts(_ values: NSSet)
+
+}
+
+// MARK: Generated accessors for excludedProducts
+extension Coupon {
+
+    @objc(addExcludedProductsObject:)
+    @NSManaged public func addToExcludedProducts(_ value: Product)
+
+    @objc(removeExcludedProductsObject:)
+    @NSManaged public func removeFromExcludedProducts(_ value: Product)
+
+    @objc(addExcludedProducts:)
+    @NSManaged public func addToExcludedProducts(_ values: NSSet)
+
+    @objc(removeExcludedProducts:)
+    @NSManaged public func removeFromExcludedProducts(_ values: NSSet)
+
+}
+
+// MARK: Generated accessors for productCategories
+extension Coupon {
+
+    @objc(addProductCategoriesObject:)
+    @NSManaged public func addToProductCategories(_ value: ProductCategory)
+
+    @objc(removeProductCategoriesObject:)
+    @NSManaged public func removeFromProductCategories(_ value: ProductCategory)
+
+    @objc(addProductCategories:)
+    @NSManaged public func addToProductCategories(_ values: NSSet)
+
+    @objc(removeProductCategories:)
+    @NSManaged public func removeFromProductCategories(_ values: NSSet)
+
+}
+
+// MARK: Generated accessors for excludedProductCategories
+extension Coupon {
+
+    @objc(addExcludedProductCategoriesObject:)
+    @NSManaged public func addToExcludedProductCategories(_ value: ProductCategory)
+
+    @objc(removeExcludedProductCategoriesObject:)
+    @NSManaged public func removeFromExcludedProductCategories(_ value: ProductCategory)
+
+    @objc(addExcludedProductCategories:)
+    @NSManaged public func addToExcludedProductCategories(_ values: NSSet)
+
+    @objc(removeExcludedProductCategories:)
+    @NSManaged public func removeFromExcludedProductCategories(_ values: NSSet)
+
+}
+
+extension Coupon: Identifiable {
+
+}

--- a/Storage/Storage/Model/Coupon+CoreDataProperties.swift
+++ b/Storage/Storage/Model/Coupon+CoreDataProperties.swift
@@ -28,78 +28,10 @@ extension Coupon {
     @NSManaged public var maximumAmount: String?
     @NSManaged public var emailRestrictions: [String]?
     @NSManaged public var usedBy: [String]?
-    @NSManaged public var products: Set<Product>?
-    @NSManaged public var excludedProducts: Set<Product>?
-    @NSManaged public var productCategories: Set<ProductCategory>?
-    @NSManaged public var excludedProductCategories: Set<ProductCategory>?
-
-}
-
-// MARK: Generated accessors for products
-extension Coupon {
-
-    @objc(addProductsObject:)
-    @NSManaged public func addToProducts(_ value: Product)
-
-    @objc(removeProductsObject:)
-    @NSManaged public func removeFromProducts(_ value: Product)
-
-    @objc(addProducts:)
-    @NSManaged public func addToProducts(_ values: NSSet)
-
-    @objc(removeProducts:)
-    @NSManaged public func removeFromProducts(_ values: NSSet)
-
-}
-
-// MARK: Generated accessors for excludedProducts
-extension Coupon {
-
-    @objc(addExcludedProductsObject:)
-    @NSManaged public func addToExcludedProducts(_ value: Product)
-
-    @objc(removeExcludedProductsObject:)
-    @NSManaged public func removeFromExcludedProducts(_ value: Product)
-
-    @objc(addExcludedProducts:)
-    @NSManaged public func addToExcludedProducts(_ values: NSSet)
-
-    @objc(removeExcludedProducts:)
-    @NSManaged public func removeFromExcludedProducts(_ values: NSSet)
-
-}
-
-// MARK: Generated accessors for productCategories
-extension Coupon {
-
-    @objc(addProductCategoriesObject:)
-    @NSManaged public func addToProductCategories(_ value: ProductCategory)
-
-    @objc(removeProductCategoriesObject:)
-    @NSManaged public func removeFromProductCategories(_ value: ProductCategory)
-
-    @objc(addProductCategories:)
-    @NSManaged public func addToProductCategories(_ values: NSSet)
-
-    @objc(removeProductCategories:)
-    @NSManaged public func removeFromProductCategories(_ values: NSSet)
-
-}
-
-// MARK: Generated accessors for excludedProductCategories
-extension Coupon {
-
-    @objc(addExcludedProductCategoriesObject:)
-    @NSManaged public func addToExcludedProductCategories(_ value: ProductCategory)
-
-    @objc(removeExcludedProductCategoriesObject:)
-    @NSManaged public func removeFromExcludedProductCategories(_ value: ProductCategory)
-
-    @objc(addExcludedProductCategories:)
-    @NSManaged public func addToExcludedProductCategories(_ values: NSSet)
-
-    @objc(removeExcludedProductCategories:)
-    @NSManaged public func removeFromExcludedProductCategories(_ values: NSSet)
+    @NSManaged public var excludedProductCategories: [Int64]?
+    @NSManaged public var excludedProducts: [Int64]?
+    @NSManaged public var products: [Int64]?
+    @NSManaged public var productCategories: [Int64]?
 
 }
 

--- a/Storage/Storage/Model/Product+CoreDataProperties.swift
+++ b/Storage/Storage/Model/Product+CoreDataProperties.swift
@@ -74,8 +74,6 @@ extension Product {
     @NSManaged public var productVariations: Set<ProductVariation>?
     @NSManaged public var productShippingClass: ProductShippingClass?
     @NSManaged public var addOns: NSOrderedSet?
-    @NSManaged public var includedInCoupons: Set<Coupon>?
-    @NSManaged public var excludedFromCoupons: Set<Coupon>?
 
 }
 
@@ -266,40 +264,6 @@ extension Product {
 
     @objc(removeProductVariations:)
     @NSManaged public func removeFromProductVariations(_ values: NSSet)
-
-}
-
-// MARK: Generated accessors for includedInCoupons
-extension Product {
-
-    @objc(addIncludedInCouponsObject:)
-    @NSManaged public func addToIncludedInCoupons(_ value: Coupon)
-
-    @objc(removeIncludedInCouponsObject:)
-    @NSManaged public func removeFromIncludedInCoupons(_ value: Coupon)
-
-    @objc(addIncludedInCoupons:)
-    @NSManaged public func addToIncludedInCoupons(_ values: NSSet)
-
-    @objc(removeIncludedInCoupons:)
-    @NSManaged public func removeFromIncludedInCoupons(_ values: NSSet)
-
-}
-
-// MARK: Generated accessors for excludedFromCoupons
-extension Product {
-
-    @objc(addExcludedFromCouponsObject:)
-    @NSManaged public func addToExcludedFromCoupons(_ value: Coupon)
-
-    @objc(removeExcludedFromCouponsObject:)
-    @NSManaged public func removeFromExcludedFromCoupons(_ value: Coupon)
-
-    @objc(addExcludedFromCoupons:)
-    @NSManaged public func addToExcludedFromCoupons(_ values: NSSet)
-
-    @objc(removeExcludedFromCoupons:)
-    @NSManaged public func removeFromExcludedFromCoupons(_ values: NSSet)
 
 }
 

--- a/Storage/Storage/Model/Product+CoreDataProperties.swift
+++ b/Storage/Storage/Model/Product+CoreDataProperties.swift
@@ -74,6 +74,8 @@ extension Product {
     @NSManaged public var productVariations: Set<ProductVariation>?
     @NSManaged public var productShippingClass: ProductShippingClass?
     @NSManaged public var addOns: NSOrderedSet?
+    @NSManaged public var includedInCoupons: Set<Coupon>?
+    @NSManaged public var excludedFromCoupons: Set<Coupon>?
 
 }
 
@@ -264,6 +266,40 @@ extension Product {
 
     @objc(removeProductVariations:)
     @NSManaged public func removeFromProductVariations(_ values: NSSet)
+
+}
+
+// MARK: Generated accessors for includedInCoupons
+extension Product {
+
+    @objc(addIncludedInCouponsObject:)
+    @NSManaged public func addToIncludedInCoupons(_ value: Coupon)
+
+    @objc(removeIncludedInCouponsObject:)
+    @NSManaged public func removeFromIncludedInCoupons(_ value: Coupon)
+
+    @objc(addIncludedInCoupons:)
+    @NSManaged public func addToIncludedInCoupons(_ values: NSSet)
+
+    @objc(removeIncludedInCoupons:)
+    @NSManaged public func removeFromIncludedInCoupons(_ values: NSSet)
+
+}
+
+// MARK: Generated accessors for excludedFromCoupons
+extension Product {
+
+    @objc(addExcludedFromCouponsObject:)
+    @NSManaged public func addToExcludedFromCoupons(_ value: Coupon)
+
+    @objc(removeExcludedFromCouponsObject:)
+    @NSManaged public func removeFromExcludedFromCoupons(_ value: Coupon)
+
+    @objc(addExcludedFromCoupons:)
+    @NSManaged public func addToExcludedFromCoupons(_ values: NSSet)
+
+    @objc(removeExcludedFromCoupons:)
+    @NSManaged public func removeFromExcludedFromCoupons(_ values: NSSet)
 
 }
 

--- a/Storage/Storage/Model/ProductCategory+CoreDataProperties.swift
+++ b/Storage/Storage/Model/ProductCategory+CoreDataProperties.swift
@@ -14,6 +14,9 @@ extension ProductCategory {
     @NSManaged public var name: String
     @NSManaged public var slug: String
     @NSManaged public var products: Set<Product>?
+    @NSManaged public var includedInCoupons: Set<Coupon>?
+    @NSManaged public var excludedFromCoupons: Set<Coupon>?
+
 }
 
 // MARK: Generated accessors for products
@@ -30,5 +33,39 @@ extension ProductCategory {
 
     @objc(removeProducts:)
     @NSManaged public func removeFromProducts(_ values: NSSet)
+
+}
+
+// MARK: Generated accessors for includedInCoupons
+extension ProductCategory {
+
+    @objc(addIncludedInCouponsObject:)
+    @NSManaged public func addToIncludedInCoupons(_ value: Coupon)
+
+    @objc(removeIncludedInCouponsObject:)
+    @NSManaged public func removeFromIncludedInCoupons(_ value: Coupon)
+
+    @objc(addIncludedInCoupons:)
+    @NSManaged public func addToIncludedInCoupons(_ values: NSSet)
+
+    @objc(removeIncludedInCoupons:)
+    @NSManaged public func removeFromIncludedInCoupons(_ values: NSSet)
+
+}
+
+// MARK: Generated accessors for excludedFromCoupons
+extension ProductCategory {
+
+    @objc(addExcludedFromCouponsObject:)
+    @NSManaged public func addToExcludedFromCoupons(_ value: Coupon)
+
+    @objc(removeExcludedFromCouponsObject:)
+    @NSManaged public func removeFromExcludedFromCoupons(_ value: Coupon)
+
+    @objc(addExcludedFromCoupons:)
+    @NSManaged public func addToExcludedFromCoupons(_ values: NSSet)
+
+    @objc(removeExcludedFromCoupons:)
+    @NSManaged public func removeFromExcludedFromCoupons(_ values: NSSet)
 
 }

--- a/Storage/Storage/Model/ProductCategory+CoreDataProperties.swift
+++ b/Storage/Storage/Model/ProductCategory+CoreDataProperties.swift
@@ -14,8 +14,6 @@ extension ProductCategory {
     @NSManaged public var name: String
     @NSManaged public var slug: String
     @NSManaged public var products: Set<Product>?
-    @NSManaged public var includedInCoupons: Set<Coupon>?
-    @NSManaged public var excludedFromCoupons: Set<Coupon>?
 
 }
 
@@ -33,39 +31,5 @@ extension ProductCategory {
 
     @objc(removeProducts:)
     @NSManaged public func removeFromProducts(_ values: NSSet)
-
-}
-
-// MARK: Generated accessors for includedInCoupons
-extension ProductCategory {
-
-    @objc(addIncludedInCouponsObject:)
-    @NSManaged public func addToIncludedInCoupons(_ value: Coupon)
-
-    @objc(removeIncludedInCouponsObject:)
-    @NSManaged public func removeFromIncludedInCoupons(_ value: Coupon)
-
-    @objc(addIncludedInCoupons:)
-    @NSManaged public func addToIncludedInCoupons(_ values: NSSet)
-
-    @objc(removeIncludedInCoupons:)
-    @NSManaged public func removeFromIncludedInCoupons(_ values: NSSet)
-
-}
-
-// MARK: Generated accessors for excludedFromCoupons
-extension ProductCategory {
-
-    @objc(addExcludedFromCouponsObject:)
-    @NSManaged public func addToExcludedFromCoupons(_ value: Coupon)
-
-    @objc(removeExcludedFromCouponsObject:)
-    @NSManaged public func removeFromExcludedFromCoupons(_ value: Coupon)
-
-    @objc(addExcludedFromCoupons:)
-    @NSManaged public func addToExcludedFromCoupons(_ values: NSSet)
-
-    @objc(removeExcludedFromCoupons:)
-    @NSManaged public func removeFromExcludedFromCoupons(_ values: NSSet)
 
 }

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/.xccurrentversion
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Model 47.xcdatamodel</string>
+	<string>Model 48.xcdatamodel</string>
 </dict>
 </plist>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 48.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 48.xcdatamodel/contents
@@ -1,0 +1,690 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17709" systemVersion="20D91" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Account" representedClassName="Account" syncable="YES">
+        <attribute name="displayName" optional="YES" attributeType="String"/>
+        <attribute name="email" optional="YES" attributeType="String"/>
+        <attribute name="gravatarUrl" optional="YES" attributeType="String"/>
+        <attribute name="userID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="username" attributeType="String"/>
+    </entity>
+    <entity name="AccountSettings" representedClassName="AccountSettings" syncable="YES">
+        <attribute name="firstName" optional="YES" attributeType="String"/>
+        <attribute name="lastName" optional="YES" attributeType="String"/>
+        <attribute name="tracksOptOut" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="userID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="Coupon" representedClassName="Coupon" syncable="YES">
+        <attribute name="amount" attributeType="String"/>
+        <attribute name="code" attributeType="String"/>
+        <attribute name="couponID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateExpires" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateModified" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="discountType" attributeType="String"/>
+        <attribute name="emailRestrictions" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
+        <attribute name="excludeSaleItems" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="freeShipping" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="fullDescription" attributeType="String"/>
+        <attribute name="individualUse" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="limitUsageToXItems" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="maximumAmount" attributeType="String"/>
+        <attribute name="minimumAmount" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usageCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usageLimit" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usageLimitPerUser" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="usedBy" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
+        <relationship name="excludedProductCategories" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductCategory" inverseName="excludedFromCoupons" inverseEntity="ProductCategory"/>
+        <relationship name="excludedProducts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Product" inverseName="excludedFromCoupons" inverseEntity="Product"/>
+        <relationship name="productCategories" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductCategory" inverseName="includedInCoupons" inverseEntity="ProductCategory"/>
+        <relationship name="products" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Product" inverseName="includedInCoupons" inverseEntity="Product"/>
+    </entity>
+    <entity name="GenericAttribute" representedClassName="GenericAttribute" syncable="YES">
+        <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="key" attributeType="String"/>
+        <attribute name="value" attributeType="String"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="attributes" inverseEntity="ProductVariation"/>
+    </entity>
+    <entity name="Note" representedClassName="Note" syncable="YES">
+        <attribute name="body" optional="YES" attributeType="Binary"/>
+        <attribute name="deleteInProgress" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="header" optional="YES" attributeType="Binary"/>
+        <attribute name="icon" optional="YES" attributeType="String"/>
+        <attribute name="meta" optional="YES" attributeType="Binary"/>
+        <attribute name="noteHash" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="noteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="noticon" optional="YES" attributeType="String"/>
+        <attribute name="read" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="subject" optional="YES" attributeType="Binary"/>
+        <attribute name="subtype" optional="YES" attributeType="String"/>
+        <attribute name="timestamp" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="Order" representedClassName="Order" syncable="YES">
+        <attribute name="billingAddress1" optional="YES" attributeType="String"/>
+        <attribute name="billingAddress2" optional="YES" attributeType="String"/>
+        <attribute name="billingCity" optional="YES" attributeType="String"/>
+        <attribute name="billingCompany" optional="YES" attributeType="String"/>
+        <attribute name="billingCountry" optional="YES" attributeType="String"/>
+        <attribute name="billingEmail" optional="YES" attributeType="String"/>
+        <attribute name="billingFirstName" optional="YES" attributeType="String"/>
+        <attribute name="billingLastName" optional="YES" attributeType="String"/>
+        <attribute name="billingPhone" optional="YES" attributeType="String"/>
+        <attribute name="billingPostcode" optional="YES" attributeType="String"/>
+        <attribute name="billingState" optional="YES" attributeType="String"/>
+        <attribute name="currency" optional="YES" attributeType="String"/>
+        <attribute name="customerID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="customerNote" optional="YES" attributeType="String"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="datePaid" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="discountTax" optional="YES" attributeType="String"/>
+        <attribute name="discountTotal" optional="YES" attributeType="String"/>
+        <attribute name="exclusiveForSearch" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="number" optional="YES" attributeType="String"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="parentID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="paymentMethodID" optional="YES" attributeType="String"/>
+        <attribute name="paymentMethodTitle" optional="YES" attributeType="String"/>
+        <attribute name="shippingAddress1" optional="YES" attributeType="String"/>
+        <attribute name="shippingAddress2" optional="YES" attributeType="String"/>
+        <attribute name="shippingCity" optional="YES" attributeType="String"/>
+        <attribute name="shippingCompany" optional="YES" attributeType="String"/>
+        <attribute name="shippingCountry" optional="YES" attributeType="String"/>
+        <attribute name="shippingEmail" optional="YES" attributeType="String"/>
+        <attribute name="shippingFirstName" optional="YES" attributeType="String"/>
+        <attribute name="shippingLastName" optional="YES" attributeType="String"/>
+        <attribute name="shippingPhone" optional="YES" attributeType="String"/>
+        <attribute name="shippingPostcode" optional="YES" attributeType="String"/>
+        <attribute name="shippingState" optional="YES" attributeType="String"/>
+        <attribute name="shippingTax" optional="YES" attributeType="String"/>
+        <attribute name="shippingTotal" optional="YES" attributeType="String"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="statusKey" attributeType="String"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <attribute name="totalTax" optional="YES" attributeType="String"/>
+        <relationship name="coupons" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderCoupon" inverseName="order" inverseEntity="OrderCoupon"/>
+        <relationship name="fees" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderFeeLine" inverseName="order" inverseEntity="OrderFeeLine"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderItem" inverseName="order" inverseEntity="OrderItem"/>
+        <relationship name="notes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderNote" inverseName="order" inverseEntity="OrderNote"/>
+        <relationship name="refunds" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderRefundCondensed" inverseName="order" inverseEntity="OrderRefundCondensed"/>
+        <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderSearchResults" inverseName="orders" inverseEntity="OrderSearchResults"/>
+        <relationship name="shippingLabels" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShippingLabel" inverseName="order" inverseEntity="ShippingLabel"/>
+        <relationship name="shippingLabelSettings" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ShippingLabelSettings" inverseName="order" inverseEntity="ShippingLabelSettings"/>
+        <relationship name="shippingLines" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShippingLine" inverseName="order" inverseEntity="ShippingLine"/>
+    </entity>
+    <entity name="OrderCount" representedClassName="OrderCount" syncable="YES">
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderCountItem" inverseName="orderCount" inverseEntity="OrderCountItem"/>
+    </entity>
+    <entity name="OrderCountItem" representedClassName="OrderCountItem" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="slug" optional="YES" attributeType="String"/>
+        <attribute name="total" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="orderCount" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderCount" inverseName="items" inverseEntity="OrderCount"/>
+    </entity>
+    <entity name="OrderCoupon" representedClassName="OrderCoupon" syncable="YES">
+        <attribute name="code" optional="YES" attributeType="String"/>
+        <attribute name="couponID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="discount" optional="YES" attributeType="String"/>
+        <attribute name="discountTax" optional="YES" attributeType="String"/>
+        <relationship name="order" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="coupons" inverseEntity="Order"/>
+    </entity>
+    <entity name="OrderFeeLine" representedClassName="OrderFeeLine" syncable="YES">
+        <attribute name="feeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="taxClass" optional="YES" attributeType="String"/>
+        <attribute name="taxStatusKey" optional="YES" attributeType="String"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <attribute name="totalTax" optional="YES" attributeType="String"/>
+        <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="OrderItemAttribute" inverseName="orderFeeLine" inverseEntity="OrderItemAttribute"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="fees" inverseEntity="Order"/>
+        <relationship name="taxes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderItemTax" inverseName="feeLine" inverseEntity="OrderItemTax"/>
+    </entity>
+    <entity name="OrderItem" representedClassName="OrderItem" syncable="YES">
+        <attribute name="itemID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="price" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="Decimal" defaultValueString="0"/>
+        <attribute name="sku" optional="YES" attributeType="String"/>
+        <attribute name="subtotal" optional="YES" attributeType="String"/>
+        <attribute name="subtotalTax" optional="YES" attributeType="String"/>
+        <attribute name="taxClass" optional="YES" attributeType="String"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <attribute name="totalTax" optional="YES" attributeType="String"/>
+        <attribute name="variationID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="OrderItemAttribute" inverseName="orderItem" inverseEntity="OrderItemAttribute"/>
+        <relationship name="order" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="items" inverseEntity="Order"/>
+        <relationship name="taxes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="OrderItemTax" inverseName="item" inverseEntity="OrderItemTax"/>
+    </entity>
+    <entity name="OrderItemAttribute" representedClassName="OrderItemAttribute" syncable="YES">
+        <attribute name="metaID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="value" attributeType="String"/>
+        <relationship name="orderFeeLine" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderFeeLine" inverseName="attributes" inverseEntity="OrderFeeLine"/>
+        <relationship name="orderItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderItem" inverseName="attributes" inverseEntity="OrderItem"/>
+    </entity>
+    <entity name="OrderItemRefund" representedClassName="OrderItemRefund" syncable="YES">
+        <attribute name="itemID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="price" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="quantity" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="sku" optional="YES" attributeType="String"/>
+        <attribute name="subtotal" optional="YES" attributeType="String"/>
+        <attribute name="subtotalTax" optional="YES" attributeType="String"/>
+        <attribute name="taxClass" optional="YES" attributeType="String"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <attribute name="totalTax" optional="YES" attributeType="String"/>
+        <attribute name="variationID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="refund" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Refund" inverseName="items" inverseEntity="Refund"/>
+        <relationship name="taxes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="OrderItemTaxRefund" inverseName="item" inverseEntity="OrderItemTaxRefund"/>
+    </entity>
+    <entity name="OrderItemTax" representedClassName="OrderItemTax" syncable="YES">
+        <attribute name="subtotal" optional="YES" attributeType="String"/>
+        <attribute name="taxID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <relationship name="feeLine" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderFeeLine" inverseName="taxes" inverseEntity="OrderFeeLine"/>
+        <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderItem" inverseName="taxes" inverseEntity="OrderItem"/>
+    </entity>
+    <entity name="OrderItemTaxRefund" representedClassName="OrderItemTaxRefund" syncable="YES">
+        <attribute name="subtotal" optional="YES" attributeType="String"/>
+        <attribute name="taxID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <relationship name="item" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderItemRefund" inverseName="taxes" inverseEntity="OrderItemRefund"/>
+    </entity>
+    <entity name="OrderNote" representedClassName="OrderNote" syncable="YES">
+        <attribute name="author" optional="YES" attributeType="String"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="isCustomerNote" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="note" optional="YES" attributeType="String"/>
+        <attribute name="noteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="notes" inverseEntity="Order"/>
+    </entity>
+    <entity name="OrderRefundCondensed" representedClassName="OrderRefundCondensed" syncable="YES">
+        <attribute name="reason" optional="YES" attributeType="String"/>
+        <attribute name="refundID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="refunds" inverseEntity="Order"/>
+    </entity>
+    <entity name="OrderSearchResults" representedClassName="OrderSearchResults" syncable="YES">
+        <attribute name="keyword" attributeType="String"/>
+        <relationship name="orders" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Order" inverseName="searchResults" inverseEntity="Order"/>
+    </entity>
+    <entity name="OrderStatsV4" representedClassName="OrderStatsV4" syncable="YES">
+        <attribute name="granularity" optional="YES" attributeType="String"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="timeRange" optional="YES" attributeType="String"/>
+        <relationship name="intervals" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="OrderStatsV4Interval" inverseName="stats" inverseEntity="OrderStatsV4Interval"/>
+        <relationship name="totals" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrderStatsV4Totals" inverseName="stats" inverseEntity="OrderStatsV4Totals"/>
+    </entity>
+    <entity name="OrderStatsV4Interval" representedClassName="OrderStatsV4Interval" syncable="YES">
+        <attribute name="dateEnd" optional="YES" attributeType="String"/>
+        <attribute name="dateStart" optional="YES" attributeType="String"/>
+        <attribute name="interval" optional="YES" attributeType="String"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4" inverseName="intervals" inverseEntity="OrderStatsV4"/>
+        <relationship name="subtotals" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrderStatsV4Totals" inverseName="interval" inverseEntity="OrderStatsV4Totals"/>
+    </entity>
+    <entity name="OrderStatsV4Totals" representedClassName="OrderStatsV4Totals" syncable="YES">
+        <attribute name="couponDiscount" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="grossRevenue" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="netRevenue" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="refunds" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="shipping" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="taxes" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
+        <attribute name="totalCoupons" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="totalItemsSold" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="totalOrders" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="totalProducts" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="interval" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4Interval" inverseName="subtotals" inverseEntity="OrderStatsV4Interval"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrderStatsV4" inverseName="totals" inverseEntity="OrderStatsV4"/>
+    </entity>
+    <entity name="OrderStatus" representedClassName="OrderStatus" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="slug" attributeType="String"/>
+        <attribute name="total" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="PaymentGateway" representedClassName="PaymentGateway" syncable="YES">
+        <attribute name="enabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="features" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
+        <attribute name="gatewayDescription" attributeType="String" defaultValueString=""/>
+        <attribute name="gatewayID" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" attributeType="String" defaultValueString=""/>
+    </entity>
+    <entity name="Product" representedClassName="Product" syncable="YES">
+        <attribute name="averageRating" attributeType="String"/>
+        <attribute name="backordered" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="backordersAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="backordersKey" attributeType="String"/>
+        <attribute name="briefDescription" optional="YES" attributeType="String"/>
+        <attribute name="buttonText" attributeType="String" defaultValueString=""/>
+        <attribute name="catalogVisibilityKey" attributeType="String"/>
+        <attribute name="crossSellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateOnSaleEnd" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateOnSaleStart" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="downloadable" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="downloadExpiry" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES"/>
+        <attribute name="downloadLimit" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES"/>
+        <attribute name="externalURL" optional="YES" attributeType="String"/>
+        <attribute name="featured" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="fullDescription" optional="YES" attributeType="String"/>
+        <attribute name="groupedProducts" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="manageStock" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="onSale" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="parentID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="permalink" attributeType="String"/>
+        <attribute name="price" attributeType="String"/>
+        <attribute name="productID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="productTypeKey" attributeType="String"/>
+        <attribute name="purchasable" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="purchaseNote" optional="YES" attributeType="String"/>
+        <attribute name="ratingCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="regularPrice" optional="YES" attributeType="String"/>
+        <attribute name="relatedIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="reviewsAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="salePrice" optional="YES" attributeType="String"/>
+        <attribute name="shippingClass" optional="YES" attributeType="String"/>
+        <attribute name="shippingClassID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="shippingRequired" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="shippingTaxable" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sku" optional="YES" attributeType="String"/>
+        <attribute name="slug" attributeType="String"/>
+        <attribute name="soldIndividually" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="statusKey" attributeType="String"/>
+        <attribute name="stockQuantity" optional="YES" attributeType="String"/>
+        <attribute name="stockStatusKey" attributeType="String"/>
+        <attribute name="taxClass" optional="YES" attributeType="String"/>
+        <attribute name="taxStatusKey" attributeType="String"/>
+        <attribute name="totalSales" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="upsellIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="variations" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="virtual" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="weight" optional="YES" attributeType="String"/>
+        <relationship name="addOns" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductAddOn" inverseName="product" inverseEntity="ProductAddOn"/>
+        <relationship name="attributes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductAttribute" inverseName="product" inverseEntity="ProductAttribute"/>
+        <relationship name="categories" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductCategory" inverseName="products" inverseEntity="ProductCategory"/>
+        <relationship name="defaultAttributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductDefaultAttribute" inverseName="product" inverseEntity="ProductDefaultAttribute"/>
+        <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductDimensions" inverseName="product" inverseEntity="ProductDimensions"/>
+        <relationship name="downloads" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductDownload" inverseName="product" inverseEntity="ProductDownload"/>
+        <relationship name="excludedFromCoupons" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Coupon" inverseName="excludedProducts" inverseEntity="Coupon"/>
+        <relationship name="images" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductImage" inverseName="product" inverseEntity="ProductImage"/>
+        <relationship name="includedInCoupons" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Coupon" inverseName="products" inverseEntity="Coupon"/>
+        <relationship name="productShippingClass" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductShippingClass" inverseName="products" inverseEntity="ProductShippingClass"/>
+        <relationship name="productVariations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductVariation" inverseName="product" inverseEntity="ProductVariation"/>
+        <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductSearchResults" inverseName="products" inverseEntity="ProductSearchResults"/>
+        <relationship name="tags" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="ProductTag" inverseName="products" inverseEntity="ProductTag"/>
+    </entity>
+    <entity name="ProductAddOn" representedClassName="ProductAddOn" syncable="YES">
+        <attribute name="adjustPrice" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="descriptionEnabled" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="descriptions" attributeType="String" defaultValueString=""/>
+        <attribute name="display" attributeType="String" defaultValueString=""/>
+        <attribute name="max" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="min" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="price" attributeType="String" defaultValueString=""/>
+        <attribute name="priceType" attributeType="String" defaultValueString=""/>
+        <attribute name="required" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="restrictions" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="restrictionsType" attributeType="String" defaultValueString=""/>
+        <attribute name="titleFormat" attributeType="String" defaultValueString=""/>
+        <attribute name="type" attributeType="String" defaultValueString=""/>
+        <relationship name="options" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductAddOnOption" inverseName="addOn" inverseEntity="ProductAddOnOption"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="addOns" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductAddOnOption" representedClassName="ProductAddOnOption" syncable="YES">
+        <attribute name="imageID" optional="YES" attributeType="String"/>
+        <attribute name="label" optional="YES" attributeType="String"/>
+        <attribute name="price" optional="YES" attributeType="String"/>
+        <attribute name="priceType" optional="YES" attributeType="String"/>
+        <relationship name="addOn" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductAddOn" inverseName="options" inverseEntity="ProductAddOn"/>
+    </entity>
+    <entity name="ProductAttribute" representedClassName="ProductAttribute" syncable="YES">
+        <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="options" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
+        <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="variation" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="visible" attributeType="Boolean" usesScalarValueType="YES"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="attributes" inverseEntity="Product"/>
+        <relationship name="terms" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductAttributeTerm" inverseName="attribute" inverseEntity="ProductAttributeTerm"/>
+    </entity>
+    <entity name="ProductAttributeTerm" representedClassName="ProductAttributeTerm" syncable="YES">
+        <attribute name="count" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="slug" attributeType="String"/>
+        <attribute name="termID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="attribute" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductAttribute" inverseName="terms" inverseEntity="ProductAttribute"/>
+    </entity>
+    <entity name="ProductCategory" representedClassName="ProductCategory" syncable="YES">
+        <attribute name="categoryID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="parentID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="slug" attributeType="String"/>
+        <relationship name="excludedFromCoupons" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Coupon" inverseName="excludedProductCategories" inverseEntity="Coupon"/>
+        <relationship name="includedInCoupons" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Coupon" inverseName="productCategories" inverseEntity="Coupon"/>
+        <relationship name="products" optional="YES" toMany="YES" deletionRule="Deny" destinationEntity="Product" inverseName="categories" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductDefaultAttribute" representedClassName="ProductDefaultAttribute" syncable="YES">
+        <attribute name="attributeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="option" optional="YES" attributeType="String"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="defaultAttributes" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductDimensions" representedClassName="ProductDimensions" syncable="YES">
+        <attribute name="height" attributeType="String"/>
+        <attribute name="length" attributeType="String"/>
+        <attribute name="width" attributeType="String"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="dimensions" inverseEntity="Product"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="dimensions" inverseEntity="ProductVariation"/>
+    </entity>
+    <entity name="ProductDownload" representedClassName="ProductDownload" syncable="YES">
+        <attribute name="downloadID" attributeType="String"/>
+        <attribute name="fileURL" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="downloads" inverseEntity="Product"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="downloads" inverseEntity="ProductVariation"/>
+    </entity>
+    <entity name="ProductImage" representedClassName="ProductImage" syncable="YES">
+        <attribute name="alt" optional="YES" attributeType="String"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="imageID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="src" attributeType="String"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="images" inverseEntity="Product"/>
+        <relationship name="productVariation" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductVariation" inverseName="image" inverseEntity="ProductVariation"/>
+    </entity>
+    <entity name="ProductReview" representedClassName="ProductReview" syncable="YES">
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="rating" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="review" optional="YES" attributeType="String"/>
+        <attribute name="reviewer" optional="YES" attributeType="String"/>
+        <attribute name="reviewerAvatarURL" optional="YES" attributeType="String"/>
+        <attribute name="reviewerEmail" optional="YES" attributeType="String"/>
+        <attribute name="reviewID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="statusKey" optional="YES" attributeType="String"/>
+        <attribute name="verified" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+    </entity>
+    <entity name="ProductSearchResults" representedClassName="ProductSearchResults" syncable="YES">
+        <attribute name="keyword" optional="YES" attributeType="String"/>
+        <relationship name="products" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Product" inverseName="searchResults" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductShippingClass" representedClassName="ProductShippingClass" syncable="YES">
+        <attribute name="count" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="descriptionHTML" optional="YES" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="shippingClassID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="slug" attributeType="String"/>
+        <relationship name="products" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Product" inverseName="productShippingClass" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductTag" representedClassName="ProductTag" syncable="YES">
+        <attribute name="name" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="slug" attributeType="String"/>
+        <attribute name="tagID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="products" optional="YES" toMany="YES" deletionRule="Deny" ordered="YES" destinationEntity="Product" inverseName="tags" inverseEntity="Product"/>
+    </entity>
+    <entity name="ProductVariation" representedClassName="ProductVariation" syncable="YES">
+        <attribute name="backordered" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="backordersAllowed" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="backordersKey" attributeType="String"/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateOnSaleEnd" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="dateOnSaleStart" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="downloadable" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="downloadExpiry" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES"/>
+        <attribute name="downloadLimit" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="YES"/>
+        <attribute name="fullDescription" optional="YES" attributeType="String"/>
+        <attribute name="manageStock" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="menuOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="onSale" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="permalink" attributeType="String"/>
+        <attribute name="price" attributeType="String"/>
+        <attribute name="productID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="productVariationID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="purchasable" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="regularPrice" optional="YES" attributeType="String"/>
+        <attribute name="salePrice" optional="YES" attributeType="String"/>
+        <attribute name="shippingClass" optional="YES" attributeType="String"/>
+        <attribute name="shippingClassID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sku" optional="YES" attributeType="String"/>
+        <attribute name="statusKey" attributeType="String"/>
+        <attribute name="stockQuantity" optional="YES" attributeType="Decimal" defaultValueString="0"/>
+        <attribute name="stockStatusKey" attributeType="String"/>
+        <attribute name="taxClass" optional="YES" attributeType="String"/>
+        <attribute name="taxStatusKey" attributeType="String"/>
+        <attribute name="virtual" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="weight" optional="YES" attributeType="String"/>
+        <relationship name="attributes" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="GenericAttribute" inverseName="productVariation" inverseEntity="GenericAttribute"/>
+        <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductDimensions" inverseName="productVariation" inverseEntity="ProductDimensions"/>
+        <relationship name="downloads" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductDownload" inverseName="productVariation" inverseEntity="ProductDownload"/>
+        <relationship name="image" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductImage" inverseName="productVariation" inverseEntity="ProductImage"/>
+        <relationship name="product" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Product" inverseName="productVariations" inverseEntity="Product"/>
+    </entity>
+    <entity name="Refund" representedClassName="Refund" syncable="YES">
+        <attribute name="amount" optional="YES" attributeType="String"/>
+        <attribute name="byUserID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="createAutomated" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="isAutomated" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="reason" optional="YES" attributeType="String"/>
+        <attribute name="refundID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="supportShippingRefunds" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="OrderItemRefund" inverseName="refund" inverseEntity="OrderItemRefund"/>
+        <relationship name="shippingLines" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShippingLine" inverseName="refund" inverseEntity="ShippingLine"/>
+    </entity>
+    <entity name="ShipmentTracking" representedClassName="ShipmentTracking" syncable="YES">
+        <attribute name="dateShipped" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="trackingID" attributeType="String"/>
+        <attribute name="trackingNumber" optional="YES" attributeType="String"/>
+        <attribute name="trackingProvider" optional="YES" attributeType="String"/>
+        <attribute name="trackingURL" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="ShipmentTrackingProvider" representedClassName="ShipmentTrackingProvider" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <relationship name="group" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShipmentTrackingProviderGroup" inverseName="providers" inverseEntity="ShipmentTrackingProviderGroup"/>
+    </entity>
+    <entity name="ShipmentTrackingProviderGroup" representedClassName="ShipmentTrackingProviderGroup" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="providers" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShipmentTrackingProvider" inverseName="group" inverseEntity="ShipmentTrackingProvider"/>
+    </entity>
+    <entity name="ShippingLabel" representedClassName="ShippingLabel" syncable="YES">
+        <attribute name="carrierID" attributeType="String" defaultValueString=""/>
+        <attribute name="currency" attributeType="String" defaultValueString=""/>
+        <attribute name="dateCreated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="packageName" attributeType="String" defaultValueString=""/>
+        <attribute name="productIDs" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="productNames" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
+        <attribute name="rate" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="refundableAmount" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="serviceName" attributeType="String" defaultValueString=""/>
+        <attribute name="shippingLabelID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="status" attributeType="String" defaultValueString=""/>
+        <attribute name="trackingNumber" attributeType="String" defaultValueString=""/>
+        <relationship name="destinationAddress" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ShippingLabelAddress" inverseName="destinationShippingLabel" inverseEntity="ShippingLabelAddress"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="shippingLabels" inverseEntity="Order"/>
+        <relationship name="originAddress" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ShippingLabelAddress" inverseName="originShippingLabel" inverseEntity="ShippingLabelAddress"/>
+        <relationship name="refund" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ShippingLabelRefund" inverseName="shippingLabel" inverseEntity="ShippingLabelRefund"/>
+    </entity>
+    <entity name="ShippingLabelAddress" representedClassName="ShippingLabelAddress" syncable="YES">
+        <attribute name="address1" attributeType="String" defaultValueString=""/>
+        <attribute name="address2" attributeType="String" defaultValueString=""/>
+        <attribute name="city" attributeType="String" defaultValueString=""/>
+        <attribute name="company" attributeType="String" defaultValueString=""/>
+        <attribute name="country" attributeType="String" defaultValueString=""/>
+        <attribute name="name" attributeType="String" defaultValueString=""/>
+        <attribute name="phone" attributeType="String" defaultValueString=""/>
+        <attribute name="postcode" attributeType="String" defaultValueString=""/>
+        <attribute name="state" attributeType="String" defaultValueString=""/>
+        <relationship name="destinationShippingLabel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShippingLabel" inverseName="destinationAddress" inverseEntity="ShippingLabel"/>
+        <relationship name="originShippingLabel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShippingLabel" inverseName="originAddress" inverseEntity="ShippingLabel"/>
+    </entity>
+    <entity name="ShippingLabelRefund" representedClassName="ShippingLabelRefund" syncable="YES">
+        <attribute name="dateRequested" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="status" attributeType="String" defaultValueString=""/>
+        <relationship name="shippingLabel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShippingLabel" inverseName="refund" inverseEntity="ShippingLabel"/>
+    </entity>
+    <entity name="ShippingLabelSettings" representedClassName="ShippingLabelSettings" syncable="YES">
+        <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="paperSize" attributeType="String" defaultValueString=""/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="shippingLabelSettings" inverseEntity="Order"/>
+    </entity>
+    <entity name="ShippingLine" representedClassName="ShippingLine" syncable="YES">
+        <attribute name="methodID" optional="YES" attributeType="String"/>
+        <attribute name="methodTitle" optional="YES" attributeType="String"/>
+        <attribute name="shippingID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <attribute name="totalTax" optional="YES" attributeType="String"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="shippingLines" inverseEntity="Order"/>
+        <relationship name="refund" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Refund" inverseName="shippingLines" inverseEntity="Refund"/>
+        <relationship name="taxes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShippingLineTax" inverseName="shipping" inverseEntity="ShippingLineTax"/>
+    </entity>
+    <entity name="ShippingLineTax" representedClassName="ShippingLineTax" syncable="YES">
+        <attribute name="subtotal" optional="YES" attributeType="String"/>
+        <attribute name="taxID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="total" optional="YES" attributeType="String"/>
+        <relationship name="shipping" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ShippingLine" inverseName="taxes" inverseEntity="ShippingLine"/>
+    </entity>
+    <entity name="Site" representedClassName="Site" syncable="YES">
+        <attribute name="gmtOffset" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="isWooCommerceActive" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="isWordPressStore" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="plan" optional="YES" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="tagline" optional="YES" attributeType="String"/>
+        <attribute name="timezone" optional="YES" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="SiteSetting" representedClassName="SiteSetting" syncable="YES">
+        <attribute name="label" optional="YES" attributeType="String"/>
+        <attribute name="settingDescription" optional="YES" attributeType="String"/>
+        <attribute name="settingGroupKey" optional="YES" attributeType="String"/>
+        <attribute name="settingID" optional="YES" attributeType="String"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="value" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="SiteVisitStats" representedClassName="SiteVisitStats" syncable="YES">
+        <attribute name="date" attributeType="String"/>
+        <attribute name="granularity" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="timeRange" attributeType="String" defaultValueString=""/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SiteVisitStatsItem" inverseName="stats" inverseEntity="SiteVisitStatsItem"/>
+    </entity>
+    <entity name="SiteVisitStatsItem" representedClassName="SiteVisitStatsItem" syncable="YES">
+        <attribute name="period" optional="YES" attributeType="String"/>
+        <attribute name="visitors" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SiteVisitStats" inverseName="items" inverseEntity="SiteVisitStats"/>
+    </entity>
+    <entity name="TaxClass" representedClassName="TaxClass" syncable="YES">
+        <attribute name="name" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="slug" attributeType="String"/>
+    </entity>
+    <entity name="TopEarnerStats" representedClassName="TopEarnerStats" syncable="YES">
+        <attribute name="date" attributeType="String"/>
+        <attribute name="granularity" attributeType="String"/>
+        <attribute name="limit" attributeType="String"/>
+        <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TopEarnerStatsItem" inverseName="stats" inverseEntity="TopEarnerStatsItem"/>
+    </entity>
+    <entity name="TopEarnerStatsItem" representedClassName="TopEarnerStatsItem" syncable="YES">
+        <attribute name="currency" optional="YES" attributeType="String"/>
+        <attribute name="imageUrl" optional="YES" attributeType="String"/>
+        <attribute name="price" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="productID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="productName" optional="YES" attributeType="String"/>
+        <attribute name="quantity" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="total" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <relationship name="stats" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TopEarnerStats" inverseName="items" inverseEntity="TopEarnerStats"/>
+    </entity>
+    <elements>
+        <element name="Account" positionX="-200.9765625" positionY="63.5625" width="128" height="120"/>
+        <element name="AccountSettings" positionX="-846" positionY="270" width="128" height="89"/>
+        <element name="GenericAttribute" positionX="-684" positionY="45" width="128" height="89"/>
+        <element name="Note" positionX="-369.61328125" positionY="-95.85546875" width="128" height="283"/>
+        <element name="Order" positionX="-41.5859375" positionY="23.53125" width="128" height="794"/>
+        <element name="OrderCount" positionX="-693" positionY="36" width="128" height="75"/>
+        <element name="OrderCountItem" positionX="-684" positionY="45" width="128" height="105"/>
+        <element name="OrderCoupon" positionX="-206.01953125" positionY="379.74609375" width="128" height="120"/>
+        <element name="OrderFeeLine" positionX="-693" positionY="45" width="128" height="164"/>
+        <element name="OrderItem" positionX="-343.4609375" positionY="444.4296875" width="128" height="268"/>
+        <element name="OrderItemAttribute" positionX="-702" positionY="27" width="128" height="104"/>
+        <element name="OrderItemRefund" positionX="-504.859375" positionY="299.1171875" width="128" height="253"/>
+        <element name="OrderItemTax" positionX="-693" positionY="36" width="128" height="104"/>
+        <element name="OrderItemTaxRefund" positionX="-675" positionY="54" width="128" height="28"/>
+        <element name="OrderNote" positionX="-505.06640625" positionY="758.75390625" width="128" height="135"/>
+        <element name="OrderRefundCondensed" positionX="-693" positionY="45" width="128" height="28"/>
+        <element name="OrderSearchResults" positionX="144.44140625" positionY="743.43359375" width="128" height="75"/>
+        <element name="OrderStatsV4" positionX="-693" positionY="36" width="128" height="120"/>
+        <element name="OrderStatsV4Interval" positionX="-675" positionY="54" width="128" height="120"/>
+        <element name="OrderStatsV4Totals" positionX="-519.01171875" positionY="96.5546875" width="128" height="225"/>
+        <element name="OrderStatus" positionX="-675" positionY="27" width="128" height="103"/>
+        <element name="PaymentGateway" positionX="-693" positionY="36" width="128" height="133"/>
+        <element name="Product" positionX="-692.92578125" positionY="1193.70703125" width="128" height="1034"/>
+        <element name="ProductAddOn" positionX="-675" positionY="63" width="128" height="284"/>
+        <element name="ProductAddOnOption" positionX="-684" positionY="54" width="128" height="104"/>
+        <element name="ProductAttribute" positionX="-733.52734375" positionY="-73.046875" width="128" height="164"/>
+        <element name="ProductAttributeTerm" positionX="-693" positionY="45" width="128" height="119"/>
+        <element name="ProductCategory" positionX="-885.69921875" positionY="65.46484375" width="128" height="149"/>
+        <element name="ProductDefaultAttribute" positionX="-819.42578125" positionY="224.1171875" width="145.12109375" height="103"/>
+        <element name="ProductDimensions" positionX="-830.15234375" positionY="345.6328125" width="128" height="118"/>
+        <element name="ProductDownload" positionX="-684" positionY="45" width="128" height="118"/>
+        <element name="ProductImage" positionX="-859.9296875" positionY="471.46484375" width="128" height="163"/>
+        <element name="ProductReview" positionX="-693" positionY="36" width="128" height="210"/>
+        <element name="ProductSearchResults" positionX="-693" positionY="36" width="128" height="75"/>
+        <element name="ProductShippingClass" positionX="-693" positionY="36" width="128" height="148"/>
+        <element name="ProductTag" positionX="-896.65234375" positionY="645.7421875" width="128" height="118"/>
+        <element name="ProductVariation" positionX="-693" positionY="36" width="128" height="598"/>
+        <element name="Refund" positionX="-394.35546875" positionY="-24.296875" width="128" height="209"/>
+        <element name="ShipmentTracking" positionX="-201.47265625" positionY="-109.14453125" width="128" height="148"/>
+        <element name="ShipmentTrackingProvider" positionX="248.25" positionY="-117.6640625" width="180.32421875" height="103"/>
+        <element name="ShipmentTrackingProviderGroup" positionX="-8.2734375" positionY="-117.890625" width="187.5" height="88"/>
+        <element name="ShippingLabel" positionX="-675" positionY="54" width="128" height="313"/>
+        <element name="ShippingLabelAddress" positionX="-684" positionY="45" width="128" height="208"/>
+        <element name="ShippingLabelRefund" positionX="-693" positionY="36" width="128" height="88"/>
+        <element name="ShippingLabelSettings" positionX="-666" positionY="63" width="128" height="103"/>
+        <element name="ShippingLine" positionX="-247.203125" positionY="907.53125" width="128" height="149"/>
+        <element name="ShippingLineTax" positionX="-693" positionY="36" width="128" height="103"/>
+        <element name="Site" positionX="-203.6875" positionY="208.0703125" width="128" height="178"/>
+        <element name="SiteSetting" positionX="-360.41015625" positionY="214.8515625" width="128" height="133"/>
+        <element name="SiteVisitStats" positionX="134.515625" positionY="224.62109375" width="128" height="118"/>
+        <element name="SiteVisitStatsItem" positionX="308.1328125" positionY="251.91796875" width="128" height="90"/>
+        <element name="TaxClass" positionX="-529.7734375" positionY="-56.109375" width="128" height="88"/>
+        <element name="TopEarnerStats" positionX="135.3828125" positionY="28.91015625" width="128" height="118"/>
+        <element name="TopEarnerStatsItem" positionX="308.53125" positionY="29.1484375" width="128" height="165"/>
+        <element name="Coupon" positionX="-684" positionY="54" width="128" height="389"/>
+    </elements>
+</model>

--- a/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 48.xcdatamodel/contents
+++ b/Storage/Storage/Model/WooCommerce.xcdatamodeld/Model 48.xcdatamodel/contents
@@ -22,6 +22,8 @@
         <attribute name="dateModified" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="discountType" attributeType="String"/>
         <attribute name="emailRestrictions" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
+        <attribute name="excludedProductCategories" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="excludedProducts" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="excludeSaleItems" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="freeShipping" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="fullDescription" attributeType="String"/>
@@ -29,15 +31,13 @@
         <attribute name="limitUsageToXItems" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="maximumAmount" attributeType="String"/>
         <attribute name="minimumAmount" attributeType="String"/>
+        <attribute name="productCategories" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
+        <attribute name="products" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[Int64]"/>
         <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="usageCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="usageLimit" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="usageLimitPerUser" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="usedBy" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
-        <relationship name="excludedProductCategories" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductCategory" inverseName="excludedFromCoupons" inverseEntity="ProductCategory"/>
-        <relationship name="excludedProducts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Product" inverseName="excludedFromCoupons" inverseEntity="Product"/>
-        <relationship name="productCategories" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ProductCategory" inverseName="includedInCoupons" inverseEntity="ProductCategory"/>
-        <relationship name="products" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Product" inverseName="includedInCoupons" inverseEntity="Product"/>
     </entity>
     <entity name="GenericAttribute" representedClassName="GenericAttribute" syncable="YES">
         <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
@@ -318,9 +318,7 @@
         <relationship name="defaultAttributes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductDefaultAttribute" inverseName="product" inverseEntity="ProductDefaultAttribute"/>
         <relationship name="dimensions" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ProductDimensions" inverseName="product" inverseEntity="ProductDimensions"/>
         <relationship name="downloads" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductDownload" inverseName="product" inverseEntity="ProductDownload"/>
-        <relationship name="excludedFromCoupons" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Coupon" inverseName="excludedProducts" inverseEntity="Coupon"/>
         <relationship name="images" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ProductImage" inverseName="product" inverseEntity="ProductImage"/>
-        <relationship name="includedInCoupons" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Coupon" inverseName="products" inverseEntity="Coupon"/>
         <relationship name="productShippingClass" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ProductShippingClass" inverseName="products" inverseEntity="ProductShippingClass"/>
         <relationship name="productVariations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductVariation" inverseName="product" inverseEntity="ProductVariation"/>
         <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ProductSearchResults" inverseName="products" inverseEntity="ProductSearchResults"/>
@@ -377,8 +375,6 @@
         <attribute name="parentID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="slug" attributeType="String"/>
-        <relationship name="excludedFromCoupons" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Coupon" inverseName="excludedProductCategories" inverseEntity="Coupon"/>
-        <relationship name="includedInCoupons" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Coupon" inverseName="productCategories" inverseEntity="Coupon"/>
         <relationship name="products" optional="YES" toMany="YES" deletionRule="Deny" destinationEntity="Product" inverseName="categories" inverseEntity="Product"/>
     </entity>
     <entity name="ProductDefaultAttribute" representedClassName="ProductDefaultAttribute" syncable="YES">
@@ -633,6 +629,7 @@
     <elements>
         <element name="Account" positionX="-200.9765625" positionY="63.5625" width="128" height="120"/>
         <element name="AccountSettings" positionX="-846" positionY="270" width="128" height="89"/>
+        <element name="Coupon" positionX="-684" positionY="54" width="128" height="389"/>
         <element name="GenericAttribute" positionX="-684" positionY="45" width="128" height="89"/>
         <element name="Note" positionX="-369.61328125" positionY="-95.85546875" width="128" height="283"/>
         <element name="Order" positionX="-41.5859375" positionY="23.53125" width="128" height="794"/>
@@ -653,12 +650,12 @@
         <element name="OrderStatsV4Totals" positionX="-519.01171875" positionY="96.5546875" width="128" height="225"/>
         <element name="OrderStatus" positionX="-675" positionY="27" width="128" height="103"/>
         <element name="PaymentGateway" positionX="-693" positionY="36" width="128" height="133"/>
-        <element name="Product" positionX="-692.92578125" positionY="1193.70703125" width="128" height="1034"/>
+        <element name="Product" positionX="-692.92578125" positionY="1193.70703125" width="128" height="1004"/>
         <element name="ProductAddOn" positionX="-675" positionY="63" width="128" height="284"/>
         <element name="ProductAddOnOption" positionX="-684" positionY="54" width="128" height="104"/>
         <element name="ProductAttribute" positionX="-733.52734375" positionY="-73.046875" width="128" height="164"/>
         <element name="ProductAttributeTerm" positionX="-693" positionY="45" width="128" height="119"/>
-        <element name="ProductCategory" positionX="-885.69921875" positionY="65.46484375" width="128" height="149"/>
+        <element name="ProductCategory" positionX="-885.69921875" positionY="65.46484375" width="128" height="119"/>
         <element name="ProductDefaultAttribute" positionX="-819.42578125" positionY="224.1171875" width="145.12109375" height="103"/>
         <element name="ProductDimensions" positionX="-830.15234375" positionY="345.6328125" width="128" height="118"/>
         <element name="ProductDownload" positionX="-684" positionY="45" width="128" height="118"/>
@@ -685,6 +682,5 @@
         <element name="TaxClass" positionX="-529.7734375" positionY="-56.109375" width="128" height="88"/>
         <element name="TopEarnerStats" positionX="135.3828125" positionY="28.91015625" width="128" height="118"/>
         <element name="TopEarnerStatsItem" positionX="308.53125" positionY="29.1484375" width="128" height="165"/>
-        <element name="Coupon" positionX="-684" positionY="54" width="128" height="389"/>
     </elements>
 </model>

--- a/Storage/StorageTests/CoreData/MigrationTests.swift
+++ b/Storage/StorageTests/CoreData/MigrationTests.swift
@@ -581,18 +581,12 @@ final class MigrationTests: XCTestCase {
         XCTAssertEqual(migratedVariation.entity.attributesByName["stockQuantity"]?.attributeType, .decimalAttributeType)
     }
 
-    func test_migrating_from_47_to_48_enables_creating_new_Coupon_and_adding_to_new_Category_and_Product_included_or_excluded_coupons_relationships() throws {
+    func test_migrating_from_47_to_48_enables_creating_new_Coupon() throws {
             // Given
             let sourceContainer = try startPersistentContainer("Model 47")
             let sourceContext = sourceContainer.viewContext
 
-            _ = insertProduct(to: sourceContext, forModel: 47)
-            _ = insertProductCategory(to: sourceContext)
-
             try sourceContext.save()
-
-            XCTAssertEqual(try sourceContext.count(entityName: "ProductCategory"), 1)
-            XCTAssertEqual(try sourceContext.count(entityName: "Product"), 1)
 
             // When
             let targetContainer = try migrate(sourceContainer, to: "Model 48")
@@ -600,25 +594,13 @@ final class MigrationTests: XCTestCase {
             // Then
             let targetContext = targetContainer.viewContext
 
-            XCTAssertEqual(try targetContext.count(entityName: "Product"), 1)
-            XCTAssertEqual(try targetContext.count(entityName: "ProductCategory"), 1)
             XCTAssertEqual(try targetContext.count(entityName: "Coupon"), 0)
 
-            let migratedProduct = try XCTUnwrap(targetContext.first(entityName: "Product"))
-            let migratedProductCategory = try XCTUnwrap(targetContext.first(entityName: "ProductCategory"))
-
-            // Creates an `Coupon` and adds products and categories to the arrays.
+            // Creates an `Coupon`
             let coupon = insertCoupon(to: targetContext)
 
-            coupon.mutableSetValue(forKey: "products").add(migratedProduct)
-            coupon.mutableSetValue(forKey: "productCategories").add(migratedProductCategory)
-            try targetContext.save()
-
             XCTAssertEqual(try targetContext.count(entityName: "Coupon"), 1)
-            let storedCoupon = try XCTUnwrap(targetContext.firstObject(ofType: Coupon.self))
-
-            XCTAssertEqual(storedCoupon.value(forKey: "products") as? Set<NSManagedObject>, [migratedProduct])
-            XCTAssertEqual(storedCoupon.value(forKey: "productCategories") as? Set<NSManagedObject>, [migratedProductCategory])
+            XCTAssertEqual(try XCTUnwrap(targetContext.firstObject(ofType: Coupon.self)), coupon)
         }
 }
 
@@ -750,7 +732,11 @@ private extension MigrationTests {
             "code": "2off2021",
             "usedBy": ["me@example.com"],
             "emailRestrictions": ["*@woocommerce.com"],
-            "siteID": 1212
+            "siteID": 1212,
+            "products": [1231, 111],
+            "excludedProducts": [19182, 192],
+            "productCategories": [1092281],
+            "excludedProductCategories": [128121212]
         ])
     }
 

--- a/Storage/StorageTests/CoreData/MigrationTests.swift
+++ b/Storage/StorageTests/CoreData/MigrationTests.swift
@@ -580,6 +580,46 @@ final class MigrationTests: XCTestCase {
         let migratedVariation = try XCTUnwrap(targetContext.first(entityName: "ProductVariation"))
         XCTAssertEqual(migratedVariation.entity.attributesByName["stockQuantity"]?.attributeType, .decimalAttributeType)
     }
+
+    func test_migrating_from_47_to_48_enables_creating_new_Coupon_and_adding_to_new_Category_and_Product_included_or_excluded_coupons_relationships() throws {
+            // Given
+            let sourceContainer = try startPersistentContainer("Model 47")
+            let sourceContext = sourceContainer.viewContext
+
+            _ = insertProduct(to: sourceContext, forModel: 47)
+            _ = insertProductCategory(to: sourceContext)
+
+            try sourceContext.save()
+
+            XCTAssertEqual(try sourceContext.count(entityName: "ProductCategory"), 1)
+            XCTAssertEqual(try sourceContext.count(entityName: "Product"), 1)
+
+            // When
+            let targetContainer = try migrate(sourceContainer, to: "Model 48")
+
+            // Then
+            let targetContext = targetContainer.viewContext
+
+            XCTAssertEqual(try targetContext.count(entityName: "Product"), 1)
+            XCTAssertEqual(try targetContext.count(entityName: "ProductCategory"), 1)
+            XCTAssertEqual(try targetContext.count(entityName: "Coupon"), 0)
+
+            let migratedProduct = try XCTUnwrap(targetContext.first(entityName: "Product"))
+            let migratedProductCategory = try XCTUnwrap(targetContext.first(entityName: "ProductCategory"))
+
+            // Creates an `Coupon` and adds products and categories to the arrays.
+            let coupon = insertCoupon(to: targetContext)
+
+            coupon.mutableSetValue(forKey: "products").add(migratedProduct)
+            coupon.mutableSetValue(forKey: "productCategories").add(migratedProductCategory)
+            try targetContext.save()
+
+            XCTAssertEqual(try targetContext.count(entityName: "Coupon"), 1)
+            let storedCoupon = try XCTUnwrap(targetContext.firstObject(ofType: Coupon.self))
+
+            XCTAssertEqual(storedCoupon.value(forKey: "products") as? Set<NSManagedObject>, [migratedProduct])
+            XCTAssertEqual(storedCoupon.value(forKey: "productCategories") as? Set<NSManagedObject>, [migratedProductCategory])
+        }
 }
 
 // MARK: - Persistent Store Setup and Migrations
@@ -685,6 +725,32 @@ private extension MigrationTests {
         context.insert(entityName: "Account", properties: [
             "userID": 0,
             "username": ""
+        ])
+    }
+
+    @discardableResult
+    func insertCoupon(to context: NSManagedObjectContext) -> NSManagedObject {
+        context.insert(entityName: "Coupon", properties: [
+            "couponID": 123123,
+            "maximumAmount": "12.00",
+            "minimumAmount": "1.00",
+            "excludeSaleItems": true,
+            "freeShipping": false,
+            "limitUsageToXItems": 3,
+            "usageLimitPerUser": 1,
+            "usageLimit": 1000,
+            "individualUse": true,
+            "usageCount": 200,
+            "dateExpires": Date(),
+            "fullDescription": "Coupon for getting discounts",
+            "discountType": "fixed_cart",
+            "dateModified": Date(),
+            "dateCreated": Date(),
+            "amount": "2.00",
+            "code": "2off2021",
+            "usedBy": ["me@example.com"],
+            "emailRestrictions": ["*@woocommerce.com"],
+            "siteID": 1212
         ])
     }
 


### PR DESCRIPTION
Part of #3912
Please ensure #3 is merged to develop before this PR

## Description
This PR adds `CouponsRemote`, with a single endpoint method for the time being: `loadAllCoupons`, which makes `GET` requests to `/coupons/` and supports pagination parameters. This method will required by the coupon list screens, to list the coupons available for a site.

The implementation here follows the existing pattern, but some further improvement to allow injection of the mapper to the remote would be helpful. This would let us test for what the siteID passed to the mapper is independently of the results of parsing coupons. I did attempt to improve on this while working on the code, but it turned out to have a bit too much complexity to do in the scope of this work. I'd be interested to improve on this in future though.

## Testing
The endpoint is not in use yet, so no applicable testing other than the unit tests, and CI once it's merged to the main repo.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
